### PR TITLE
Continue annotation view

### DIFF
--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationMarkdownViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationMarkdownViewModel.swift
@@ -1,8 +1,8 @@
 import UIKit
 
 class DocumentAnnotationMarkdownViewModel: DocumentAnnotationTextViewModel {
-    init(content: String, height: Double) {
-        super.init(content: content, height: height, annotationType: .markdown)
+    init(id: UUID, content: String, height: Double) {
+        super.init(id: id, content: content, height: height, annotationType: .markdown)
     }
 
     override func toView<T>(in parentView: T) -> DocumentAnnotationSectionView where T: UIView {

--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationMarkdownViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationMarkdownViewModel.swift
@@ -7,9 +7,14 @@ class DocumentAnnotationMarkdownViewModel: DocumentAnnotationTextViewModel {
 
     override func toView<T>(in parentView: T) -> DocumentAnnotationSectionView where T: UIView {
         let frame = CGRect(x: .zero, y: .zero, width: parentView.frame.width, height: height)
-        let view = DocumentAnnotationMarkdownView(frame: frame, textContainer: nil)
+        let view = DocumentAnnotationMarkdownView(
+            frame: frame,
+            textContainer: nil,
+            viewModel: self
+        )
         view.text = content
         view.delegate = parentView as? DocumentAnnotationView
+        view.actionDelegate = parentView as? DocumentAnnotationView
         return view
     }
 }

--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationMarkdownViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationMarkdownViewModel.swift
@@ -13,7 +13,6 @@ class DocumentAnnotationMarkdownViewModel: DocumentAnnotationTextViewModel {
             viewModel: self
         )
         view.text = content
-        view.delegate = parentView as? DocumentAnnotationView
         view.actionDelegate = parentView as? DocumentAnnotationView
         return view
     }

--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationPartViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationPartViewModel.swift
@@ -3,6 +3,7 @@ import UIKit
 protocol DocumentAnnotationPartViewModel {
     var isEmpty: Bool { get }
     var annotationType: AnnotationType { get }
+    var id: UUID { get }
     var content: String { get }
     var height: Double { get }
     func toView<T: UIView>(in parentView: T) -> DocumentAnnotationSectionView

--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationTextViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationTextViewModel.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import UIKit
 
 class DocumentAnnotationTextViewModel: DocumentAnnotationPartViewModel {
+    private(set) var id: UUID
     private(set) var annotationType: AnnotationType
     private(set) var content: String
     private(set) var height: Double
@@ -10,7 +11,8 @@ class DocumentAnnotationTextViewModel: DocumentAnnotationPartViewModel {
         content.isEmpty
     }
 
-    init(content: String, height: Double, annotationType: AnnotationType = .plainText) {
+    init(id: UUID, content: String, height: Double, annotationType: AnnotationType = .plainText) {
+        self.id = id
         self.annotationType = annotationType
         self.content = content
         self.height = height

--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationTextViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationTextViewModel.swift
@@ -24,8 +24,15 @@ class DocumentAnnotationTextViewModel: DocumentAnnotationPartViewModel {
             viewModel: self
         )
         view.text = content
-        view.delegate = parentView as? DocumentAnnotationView
         view.actionDelegate = parentView as? DocumentAnnotationView
         return view
+    }
+
+    func setContent(to newContent: String) {
+        self.content = newContent
+    }
+
+    func setHeight(to newHeight: Double) {
+        self.height = newHeight
     }
 }

--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationTextViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationTextViewModel.swift
@@ -18,9 +18,14 @@ class DocumentAnnotationTextViewModel: DocumentAnnotationPartViewModel {
 
     func toView<T>(in parentView: T) -> DocumentAnnotationSectionView where T: UIView {
         let frame = CGRect(x: .zero, y: .zero, width: parentView.frame.width, height: height)
-        let view = DocumentAnnotationTextView(frame: frame, textContainer: nil)
+        let view = DocumentAnnotationTextView(
+            frame: frame,
+            textContainer: nil,
+            viewModel: self
+        )
         view.text = content
         view.delegate = parentView as? DocumentAnnotationView
+        view.actionDelegate = parentView as? DocumentAnnotationView
         return view
     }
 }

--- a/Annotato/Annotato/ViewModels/Document/DocumentAnnotationViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentAnnotationViewModel.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 
 class DocumentAnnotationViewModel {
     private(set) var center: CGPoint
@@ -11,8 +12,7 @@ class DocumentAnnotationViewModel {
         self.parts = parts
 
         if self.parts.isEmpty {
-            self.parts.append(DocumentAnnotationTextViewModel(
-                content: "", height: 50.0, annotationType: .plainText))
+            _ = addPart(for: .plainText)
         }
     }
 
@@ -28,5 +28,23 @@ class DocumentAnnotationViewModel {
 
     var startingAnnotationType: AnnotationType? {
         isNew ? self.parts[0].annotationType : nil
+    }
+
+    func addPart(for annotationType: AnnotationType) -> DocumentAnnotationPartViewModel {
+        let newViewModel: DocumentAnnotationPartViewModel
+
+        switch annotationType {
+        case .plainText:
+            newViewModel = DocumentAnnotationTextViewModel(id: UUID(), content: "", height: 50.0)
+        case .markdown:
+            newViewModel = DocumentAnnotationMarkdownViewModel(id: UUID(), content: "", height: 50.0)
+        }
+        parts.append(newViewModel)
+
+        return newViewModel
+    }
+
+    func removePart(part: DocumentAnnotationPartViewModel) {
+        parts.removeAll(where: { $0.id == part.id })
     }
 }

--- a/Annotato/Annotato/ViewModels/Sample/SampleData.swift
+++ b/Annotato/Annotato/ViewModels/Sample/SampleData.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 
 class SampleData {
     func exampleDocumentsInList() -> [DocumentListViewModel] {
@@ -31,17 +32,21 @@ class SampleData {
 
     private func exampleAnnotationParts1() -> [DocumentAnnotationPartViewModel] {
         [
-            DocumentAnnotationTextViewModel(content: "I am hungry", height: 30.0),
-            DocumentAnnotationTextViewModel(content: "ABC\nDEF", height: 60.0)
+            DocumentAnnotationTextViewModel(id: UUID(), content: "I am hungry", height: 30.0),
+            DocumentAnnotationTextViewModel(id: UUID(), content: "ABC\nDEF", height: 60.0)
         ]
     }
 
     private func exampleAnnotationParts2() -> [DocumentAnnotationPartViewModel] {
         [
             DocumentAnnotationTextViewModel(
+                id: UUID(),
                 content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 height: 44.0),
-            DocumentAnnotationTextViewModel(content: "Hello\nHello\nHello", height: 60.0)
+            DocumentAnnotationTextViewModel(
+                id: UUID(),
+                content: "Hello\nHello\nHello",
+                height: 60.0)
         ]
     }
 }

--- a/Annotato/Annotato/Views/Components/ToggleableButton.swift
+++ b/Annotato/Annotato/Views/Components/ToggleableButton.swift
@@ -27,6 +27,14 @@ class ToggleableButton: UIButton {
 
     @objc
     private func didTap() {
-        isSelected.toggle()
+        select()
+    }
+
+    func select() {
+        isSelected = true
+    }
+
+    func unselect() {
+        isSelected = false
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationDelegate.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationDelegate.swift
@@ -1,0 +1,3 @@
+protocol DocumentAnnotationDelegate: AnyObject {
+    func didSelect(selected: DocumentAnnotationView)
+}

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationMarkdownView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationMarkdownView.swift
@@ -4,8 +4,12 @@ class DocumentAnnotationMarkdownView: DocumentAnnotationTextView {
     private var markdownView: UIView?
     let frameHeightMultiplier: Double = 2
 
-    init(frame: CGRect, textContainer: NSTextContainer?) {
-        super.init(frame: frame, textContainer: textContainer, annotationType: .markdown)
+    init(
+        frame: CGRect,
+        textContainer: NSTextContainer?,
+        viewModel: DocumentAnnotationMarkdownViewModel
+    ) {
+        super.init(frame: frame, textContainer: textContainer, viewModel: viewModel)
     }
 
     override func enterEditMode() {

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationMarkdownView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationMarkdownView.swift
@@ -25,9 +25,14 @@ class DocumentAnnotationMarkdownView: DocumentAnnotationTextView {
         isEditable = false
 
         let annotatoMarkdown = AnnotatoMarkdown()
+        let widthOffset = 5.0
+        let heightOffset = textContainerInset.top
         let markdownFrame = CGRect(
-            origin: .zero,
-            size: self.frame.size
+            origin: CGPoint(x: widthOffset, y: heightOffset),
+            size: CGSize(
+                width: self.frame.width - widthOffset * 2,
+                height: self.frame.height - heightOffset * 2
+            )
         )
         let markdownView = annotatoMarkdown.renderMarkdown(from: text, frame: markdownFrame)
         markdownView.backgroundColor = UIColor.white

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionDelegate.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionDelegate.swift
@@ -1,0 +1,4 @@
+protocol DocumentAnnotationSectionDelegate: AnyObject {
+    func didSelect(section: DocumentAnnotationSectionView)
+    func didBecomeEmpty(section: DocumentAnnotationSectionView)
+}

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionDelegate.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionDelegate.swift
@@ -1,4 +1,6 @@
 protocol DocumentAnnotationSectionDelegate: AnyObject {
     func didSelect(section: DocumentAnnotationSectionView)
     func didBecomeEmpty(section: DocumentAnnotationSectionView)
+    func frameDidChange()
+    func didBeginEditing(annotationType: AnnotationType)
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionView.swift
@@ -2,6 +2,7 @@ import UIKit
 
 protocol DocumentAnnotationSectionView where Self: UIView {
     var annotationType: AnnotationType { get }
+    var partViewModel: DocumentAnnotationPartViewModel { get }
     var isEmpty: Bool { get }
     func enterEditMode()
     func enterViewMode()

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationSectionView.swift
@@ -5,4 +5,29 @@ protocol DocumentAnnotationSectionView where Self: UIView {
     var isEmpty: Bool { get }
     func enterEditMode()
     func enterViewMode()
+    func showSelected()
+}
+
+extension DocumentAnnotationSectionView {
+    func showSelected() {
+        let oldColor = backgroundColor
+        let duration = 0.2
+        let red: CGFloat = 245 / 255
+        let green: CGFloat = 234 / 255
+        let blue: CGFloat = 105 / 255
+        let alpha: CGFloat = 0.3
+        let color = UIColor(red: red, green: green, blue: blue, alpha: alpha)
+
+        UIView.animate(
+            withDuration: duration,
+            animations: {
+                self.backgroundColor = color
+            },
+            completion: { _ in
+                UIView.animate(withDuration: duration) {
+                    self.backgroundColor = oldColor
+                }
+            }
+        )
+    }
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
@@ -3,6 +3,9 @@ import UIKit
 class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
     weak var actionDelegate: DocumentAnnotationSectionDelegate?
     private(set) var viewModel: DocumentAnnotationTextViewModel
+    var partViewModel: DocumentAnnotationPartViewModel {
+        viewModel
+    }
 
     var annotationType: AnnotationType {
         viewModel.annotationType

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
@@ -25,8 +25,6 @@ class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
         self.viewModel = viewModel
         super.init(frame: frame, textContainer: textContainer)
 
-        self.layer.borderColor = UIColor.black.cgColor
-        self.layer.borderWidth = 2.0
         translatesAutoresizingMaskIntoConstraints = false
         isScrollEnabled = false
         addTapGestureRecognizer()
@@ -50,6 +48,7 @@ class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
 
     @objc private func didTap() {
         if isEditable {
+            showSelected()
             actionDelegate?.didSelect(section: self)
         }
     }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
@@ -25,6 +25,7 @@ class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
         self.viewModel = viewModel
         super.init(frame: frame, textContainer: textContainer)
 
+        delegate = self
         translatesAutoresizingMaskIntoConstraints = false
         isScrollEnabled = false
         addTapGestureRecognizer()
@@ -52,12 +53,6 @@ class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
             actionDelegate?.didSelect(section: self)
         }
     }
-
-    @objc private func didEdit() {
-        if isEmpty {
-            actionDelegate?.didBecomeEmpty(section: self)
-        }
-    }
 }
 
 extension DocumentAnnotationTextView: UIGestureRecognizerDelegate {
@@ -66,5 +61,27 @@ extension DocumentAnnotationTextView: UIGestureRecognizerDelegate {
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
         true
+    }
+}
+
+extension DocumentAnnotationTextView: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        let fixedWidth = frame.size.width
+        let newSize = sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+        frame.size = CGSize(width: max(newSize.width, fixedWidth), height: newSize.height)
+
+        viewModel.setContent(to: text)
+        viewModel.setHeight(to: frame.size.height)
+        actionDelegate?.frameDidChange()
+    }
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        actionDelegate?.didBeginEditing(annotationType: annotationType)
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if isEmpty {
+            actionDelegate?.didBecomeEmpty(section: self)
+        }
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationTextView.swift
@@ -1,7 +1,12 @@
 import UIKit
 
 class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
-    private(set) var annotationType: AnnotationType
+    weak var actionDelegate: DocumentAnnotationSectionDelegate?
+    private(set) var viewModel: DocumentAnnotationTextViewModel
+
+    var annotationType: AnnotationType {
+        viewModel.annotationType
+    }
 
     var isEmpty: Bool {
         text.isEmpty
@@ -15,15 +20,16 @@ class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
     init(
         frame: CGRect,
         textContainer: NSTextContainer?,
-        annotationType: AnnotationType = .plainText
+        viewModel: DocumentAnnotationTextViewModel
     ) {
-        self.annotationType = annotationType
+        self.viewModel = viewModel
         super.init(frame: frame, textContainer: textContainer)
 
         self.layer.borderColor = UIColor.black.cgColor
         self.layer.borderWidth = 2.0
         translatesAutoresizingMaskIntoConstraints = false
         isScrollEnabled = false
+        addTapGestureRecognizer()
     }
 
     func enterEditMode() {
@@ -32,5 +38,34 @@ class DocumentAnnotationTextView: UITextView, DocumentAnnotationSectionView {
 
     func enterViewMode() {
         isEditable = false
+    }
+
+    private func addTapGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer(
+            target: self, action: #selector(didTap)
+        )
+        gestureRecognizer.delegate = self
+        addGestureRecognizer(gestureRecognizer)
+    }
+
+    @objc private func didTap() {
+        if isEditable {
+            actionDelegate?.didSelect(section: self)
+        }
+    }
+
+    @objc private func didEdit() {
+        if isEmpty {
+            actionDelegate?.didBecomeEmpty(section: self)
+        }
+    }
+}
+
+extension DocumentAnnotationTextView: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarDelegate.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarDelegate.swift
@@ -2,4 +2,5 @@ protocol DocumentAnnotationToolbarDelegate: AnyObject {
     func enterEditMode()
     func enterViewMode()
     func addOrReplaceSection(with annotationType: AnnotationType)
+    func didDelete()
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarView.swift
@@ -26,9 +26,10 @@ class DocumentAnnotationToolbarView: UIToolbar {
 
         textButton = makeTextButton()
         markdownButton = makeMarkdownButton()
+        let deleteButton = makeDeleteButton()
         initializeEditButton(isEditable: annotationViewModel.isNew)
         initializePalette(startingAnnotationType: annotationViewModel.startingAnnotationType)
-        self.items = [textButton, markdownButton, flexibleSpace, editButton]
+        self.items = [textButton, markdownButton, flexibleSpace, editButton, deleteButton]
     }
 
     private func makeTextButton() -> UIBarButtonItem {
@@ -52,6 +53,15 @@ class DocumentAnnotationToolbarView: UIToolbar {
         button.tintColor = .darkGray
         button.delegate = self
         return button
+    }
+
+    private func makeDeleteButton() -> UIBarButtonItem {
+        let button = UIButton()
+        let imageName = "trash"
+        button.setImage(UIImage(systemName: imageName), for: .normal)
+        button.sizeToFit()
+        button.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
+        return UIBarButtonItem(customView: button)
     }
 
     private func initializeEditButton(isEditable: Bool) {
@@ -91,7 +101,48 @@ class DocumentAnnotationToolbarView: UIToolbar {
         button.addTarget(self, action: #selector(didTapEditButton), for: .touchUpInside)
         editButton.customView = button
     }
+}
 
+// MARK: Palette
+extension DocumentAnnotationToolbarView: ToggleableButtonDelegate {
+    func didSelect(button: ToggleableButton) {
+        for paletteButton in paletteButtons.values where paletteButton != button {
+            paletteButton.isSelected = false
+        }
+    }
+
+    func tapButton(of annotationType: AnnotationType) {
+        switch annotationType {
+        case .plainText:
+            guard let plainTextButton = paletteButtons[.plainText] else {
+                return
+            }
+            plainTextButton.select()
+        case .markdown:
+            guard let markdownButton = paletteButtons[.markdown] else {
+                return
+            }
+            markdownButton.select()
+        }
+    }
+
+    @objc
+    private func didTapTextButton(_ sender: ToggleableButton) {
+        if sender.isSelected {
+            actionDelegate?.addOrReplaceSection(with: .plainText)
+        }
+    }
+
+    @objc
+    private func didTapMarkdownButton(_ sender: ToggleableButton) {
+        if sender.isSelected {
+            actionDelegate?.addOrReplaceSection(with: .markdown)
+        }
+    }
+}
+
+// MARK: Edit
+extension DocumentAnnotationToolbarView {
     @objc
     private func didTapEditButton() {
         editButton.isSelected.toggle()
@@ -129,39 +180,10 @@ class DocumentAnnotationToolbarView: UIToolbar {
     }
 }
 
-extension DocumentAnnotationToolbarView: ToggleableButtonDelegate {
-    func didSelect(button: ToggleableButton) {
-        for paletteButton in paletteButtons.values where paletteButton != button {
-            paletteButton.isSelected = false
-        }
-    }
-
-    func tapButton(of annotationType: AnnotationType) {
-        switch annotationType {
-        case .plainText:
-            guard let plainTextButton = paletteButtons[.plainText] else {
-                return
-            }
-            plainTextButton.select()
-        case .markdown:
-            guard let markdownButton = paletteButtons[.markdown] else {
-                return
-            }
-            markdownButton.select()
-        }
-    }
-
+// MARK: Delete
+extension DocumentAnnotationToolbarView {
     @objc
-    private func didTapTextButton(_ sender: ToggleableButton) {
-        if sender.isSelected {
-            actionDelegate?.addOrReplaceSection(with: .plainText)
-        }
-    }
-
-    @objc
-    private func didTapMarkdownButton(_ sender: ToggleableButton) {
-        if sender.isSelected {
-            actionDelegate?.addOrReplaceSection(with: .markdown)
-        }
+    func didTapDeleteButton() {
+        actionDelegate?.didDelete()
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarView.swift
@@ -74,14 +74,12 @@ class DocumentAnnotationToolbarView: UIToolbar {
             guard let button = paletteButtons[.plainText] else {
                 return
             }
-            button.isSelected = true
-            didTapTextButton(button)
+            button.select()
         case .markdown:
             guard let button = paletteButtons[.markdown] else {
                 return
             }
-            button.isSelected = true
-            didTapMarkdownButton(button)
+            button.select()
         }
     }
 
@@ -119,6 +117,7 @@ class DocumentAnnotationToolbarView: UIToolbar {
 
     private func disablePalette() {
         for paletteButton in paletteButtons.values {
+            paletteButton.unselect()
             paletteButton.isEnabled = false
         }
     }
@@ -128,6 +127,21 @@ extension DocumentAnnotationToolbarView: ToggleableButtonDelegate {
     func didSelect(button: ToggleableButton) {
         for paletteButton in paletteButtons.values where paletteButton != button {
             paletteButton.isSelected = false
+        }
+    }
+
+    func tapButton(of annotationType: AnnotationType) {
+        switch annotationType {
+        case .plainText:
+            guard let plainTextButton = paletteButtons[.plainText] else {
+                return
+            }
+            plainTextButton.select()
+        case .markdown:
+            guard let markdownButton = paletteButtons[.markdown] else {
+                return
+            }
+            markdownButton.select()
         }
     }
 

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationToolbarView.swift
@@ -99,6 +99,12 @@ class DocumentAnnotationToolbarView: UIToolbar {
         enterEditOrViewMode()
     }
 
+    func disableEdit() {
+        editButton.isSelected = false
+        setEditButtonView()
+        enterEditOrViewMode()
+    }
+
     private func enterEditOrViewMode() {
         if editButton.isSelected {
             enablePalette()

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
@@ -111,44 +111,19 @@ class DocumentAnnotationView: UIView {
         newAnnotationFrame.size.height = min(maxHeight, max(minHeight, targetAnnotationHeight))
         self.frame = newAnnotationFrame
     }
-}
 
-extension DocumentAnnotationView: UITextViewDelegate {
-    func resize() {
+    private func resize() {
         resizeStackView()
         resizeAnnotationView()
-    }
-
-    func textViewDidChange(_ textView: UITextView) {
-        let fixedWidth = textView.frame.size.width
-        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-        textView.frame.size = CGSize(width: max(newSize.width, fixedWidth), height: newSize.height)
-
-        resize()
-    }
-
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        guard let textView = textView as? DocumentAnnotationTextView else {
-            return
-        }
-
-        toolbar?.tapButton(of: textView.annotationType)
-    }
-
-    func textViewDidEndEditing(_ textView: UITextView) {
-        guard let textView = textView as? DocumentAnnotationTextView else {
-            return
-        }
-
-        if textView.isEmpty {
-            didBecomeEmpty(section: textView)
-        }
     }
 }
 
 // MARK: Gestures
 extension DocumentAnnotationView {
     func didResignFocus() {
+        if viewModel.isNew {
+            didDelete()
+        }
         toolbar?.disableEdit()
     }
 
@@ -184,6 +159,10 @@ extension DocumentAnnotationView {
 }
 
 extension DocumentAnnotationView: DocumentAnnotationSectionDelegate {
+    func didBeginEditing(annotationType: AnnotationType) {
+        toolbar?.tapButton(of: annotationType)
+    }
+
     func didSelect(section: DocumentAnnotationSectionView) {
         selectedSection = section
     }
@@ -201,6 +180,10 @@ extension DocumentAnnotationView: DocumentAnnotationSectionDelegate {
         sections.removeAll(where: { $0 == section })
         resize()
         selectedSection = nil
+    }
+
+    func frameDidChange() {
+        resize()
     }
 }
 
@@ -255,5 +238,9 @@ extension DocumentAnnotationView: DocumentAnnotationToolbarDelegate {
         newSection.becomeFirstResponder()
         sections.append(newSection)
         stackView.addArrangedSubview(newSection)
+    }
+
+    func didDelete() {
+        self.removeFromSuperview()
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
@@ -172,7 +172,7 @@ extension DocumentAnnotationView: DocumentAnnotationSectionDelegate {
             return
         }
 
-        if section == lastSection {
+        if section == lastSection && sections.count == 1 {
             return
         }
 
@@ -205,6 +205,7 @@ extension DocumentAnnotationView: DocumentAnnotationToolbarDelegate {
         }
 
         if lastSection.annotationType == annotationType {
+            lastSection.becomeFirstResponder()
             return
         }
 

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
@@ -252,6 +252,7 @@ extension DocumentAnnotationView: DocumentAnnotationToolbarDelegate {
         }
 
         let newSection = newViewModel.toView(in: self)
+        newSection.becomeFirstResponder()
         sections.append(newSection)
         stackView.addArrangedSubview(newSection)
     }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
@@ -10,6 +10,7 @@ class DocumentAnnotationView: UIView {
     let scrollViewMaxHeight = 200.0
     private var scrollView = UIScrollView()
     private var stackView = UIStackView()
+    private var toolbar: DocumentAnnotationToolbarView?
 
     @available(*, unavailable)
     required init(coder: NSCoder) {
@@ -93,6 +94,7 @@ class DocumentAnnotationView: UIView {
         toolbar.translatesAutoresizingMaskIntoConstraints = true
         toolbar.actionDelegate = self
         addSubview(toolbar)
+        self.toolbar = toolbar
     }
 
     private func addPanGestureRecognizer() {
@@ -136,6 +138,14 @@ extension DocumentAnnotationView: UITextViewDelegate {
         textView.frame.size = CGSize(width: max(newSize.width, fixedWidth), height: newSize.height)
 
         resize()
+    }
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        guard let textView = textView as? DocumentAnnotationTextView else {
+            return
+        }
+
+        toolbar?.tapButton(of: textView.annotationType)
     }
 }
 

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
@@ -176,8 +176,7 @@ extension DocumentAnnotationView: DocumentAnnotationSectionDelegate {
             return
         }
 
-        section.removeFromSuperview()
-        sections.removeAll(where: { $0 == section })
+        removeSection(section: section)
         resize()
         selectedSection = nil
     }
@@ -210,9 +209,7 @@ extension DocumentAnnotationView: DocumentAnnotationToolbarDelegate {
         }
 
         if lastSection.isEmpty {
-            let lastSection = sections.last
-            lastSection?.removeFromSuperview()
-            sections.removeLast()
+            removeSection(section: lastSection)
         }
 
         if sections.last?.annotationType == annotationType {
@@ -225,19 +222,17 @@ extension DocumentAnnotationView: DocumentAnnotationToolbarDelegate {
     }
 
     private func addNewSection(basedOn annotationType: AnnotationType) {
-        let newViewModel: DocumentAnnotationPartViewModel
-
-        switch annotationType {
-        case .plainText:
-            newViewModel = DocumentAnnotationTextViewModel(content: "", height: 50.0)
-        case .markdown:
-            newViewModel = DocumentAnnotationMarkdownViewModel(content: "", height: 50.0)
-        }
-
+        let newViewModel = viewModel.addPart(for: annotationType)
         let newSection = newViewModel.toView(in: self)
         newSection.becomeFirstResponder()
         sections.append(newSection)
         stackView.addArrangedSubview(newSection)
+    }
+
+    private func removeSection(section: DocumentAnnotationSectionView) {
+        viewModel.removePart(part: section.partViewModel)
+        section.removeFromSuperview()
+        sections.removeAll(where: { $0 == section })
     }
 
     func didDelete() {

--- a/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentAnnotationView.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 class DocumentAnnotationView: UIView {
+    weak var delegate: DocumentAnnotationDelegate?
     private var viewModel: DocumentAnnotationViewModel
     private var sections: [DocumentAnnotationSectionView] = []
     private var selectedSection: DocumentAnnotationSectionView?
@@ -36,7 +37,7 @@ class DocumentAnnotationView: UIView {
         self.layer.borderColor = UIColor.blue.cgColor
         makeScrollView()
         makeStackView()
-        addPanGestureRecognizer()
+        addGestureRecognizers()
         initializeSubviews()
     }
 
@@ -147,6 +148,25 @@ extension DocumentAnnotationView: UITextViewDelegate {
 
 // MARK: Gestures
 extension DocumentAnnotationView {
+    func didResignFocus() {
+        toolbar?.disableEdit()
+    }
+
+    func addGestureRecognizers() {
+        addTapGestureRecognizer()
+        addPanGestureRecognizer()
+    }
+
+    private func addTapGestureRecognizer() {
+        isUserInteractionEnabled = true
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTap))
+        addGestureRecognizer(gestureRecognizer)
+    }
+
+    @objc private func didTap() {
+        delegate?.didSelect(selected: self)
+    }
+
     private func addPanGestureRecognizer() {
         isUserInteractionEnabled = true
         let gestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(didPan))

--- a/Annotato/Podfile.lock
+++ b/Annotato/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
   - Down (0.11.0)
-  - Firebase/Auth (8.12.1):
+  - Firebase/Auth (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.12.0)
-  - Firebase/CoreOnly (8.12.1):
-    - FirebaseCore (= 8.12.1)
-  - FirebaseAuth (8.12.0):
+    - FirebaseAuth (~> 8.13.0)
+  - Firebase/CoreOnly (8.13.0):
+    - FirebaseCore (= 8.13.0)
+  - FirebaseAuth (8.13.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/Environment (~> 7.7)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.12.1):
+  - FirebaseCore (8.13.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.12.0):
+  - FirebaseCoreDiagnostics (8.13.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
@@ -77,10 +77,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Down: b6ba1bc985c9d2f4e15e3b293d2207766fa12612
-  Firebase: 580d09e8edafc3073ebf09c03fd42e4d80d35fe9
-  FirebaseAuth: 5250d7bdba35e57cc34ec7ddc525f82b2757f2a0
-  FirebaseCore: 8138de860a90ca7eec5e324da5788fb0ebf1d93c
-  FirebaseCoreDiagnostics: 3b40dfadef5b90433a60ae01f01e90fe87aa76aa
+  Firebase: ee9b1d9b1801371e29f5591eda89eb5a314ab599
+  FirebaseAuth: ee43cf9474641c673a3a215ac92ab99e5630620c
+  FirebaseCore: c7e3fa30492e50ccdeef280bf0d5584af38da3e1
+  FirebaseCoreDiagnostics: c2836d254a8f0bbb4121ff18f2c2ea39d118fd08
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91

--- a/Annotato/Podfile.lock
+++ b/Annotato/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
   - Down (0.11.0)
-  - Firebase/Auth (8.13.0):
+  - Firebase/Auth (8.12.1):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.13.0)
-  - Firebase/CoreOnly (8.13.0):
-    - FirebaseCore (= 8.13.0)
-  - FirebaseAuth (8.13.0):
+    - FirebaseAuth (~> 8.12.0)
+  - Firebase/CoreOnly (8.12.1):
+    - FirebaseCore (= 8.12.1)
+  - FirebaseAuth (8.12.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/Environment (~> 7.7)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.13.0):
+  - FirebaseCore (8.12.1):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.13.0):
+  - FirebaseCoreDiagnostics (8.12.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
@@ -77,10 +77,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Down: b6ba1bc985c9d2f4e15e3b293d2207766fa12612
-  Firebase: ee9b1d9b1801371e29f5591eda89eb5a314ab599
-  FirebaseAuth: ee43cf9474641c673a3a215ac92ab99e5630620c
-  FirebaseCore: c7e3fa30492e50ccdeef280bf0d5584af38da3e1
-  FirebaseCoreDiagnostics: c2836d254a8f0bbb4121ff18f2c2ea39d118fd08
+  Firebase: 580d09e8edafc3073ebf09c03fd42e4d80d35fe9
+  FirebaseAuth: 5250d7bdba35e57cc34ec7ddc525f82b2757f2a0
+  FirebaseCore: 8138de860a90ca7eec5e324da5788fb0ebf1d93c
+  FirebaseCoreDiagnostics: 3b40dfadef5b90433a60ae01f01e90fe87aa76aa
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91


### PR DESCRIPTION
Continued the following for annotation view:
- Detect when an annotation section is selected, and show user when they select it
- Delete section when it becomes empty and is not the last section
- Detect when annotation is out of focus (when you tap outside an annotation)
  - This is a little problematic, as it does not detect when a subview of an annotation is also tapped, to be fixed later
  - Delete annotation if empty
  - Change annotation to view mode when out of focus
- Update view model
- Add deletion method
- Adjust markdown view position

To be done in subsequent PRs:
- Change the selected section when toolbar is tapped...
- Minimise
- Drawing
- Flow to persistence (some of the update view model methods are a bit messy right now, will fix then when doing to the flow to model/ persistence)

I think this PR can be merged in first if the first section stuff are okay? Otherwise it would be too big. 