### PR TITLE
Add and use remote API endpoint

### DIFF
--- a/Annotato/Annotato/API/BaseAPI.swift
+++ b/Annotato/Annotato/API/BaseAPI.swift
@@ -1,3 +1,6 @@
 struct BaseAPI {
-    static let baseAPIUrl = "http://127.0.0.1:8080" // localhost
+    private static let localApiEndpoint = "http://127.0.0.1:8080"
+    private static let remoteApiEndpoint = "http://178.128.111.22:80"
+
+    static let baseAPIUrl = remoteApiEndpoint
 }


### PR DESCRIPTION
Changes
- Change endpoint to point to DigitalOcean droplet so that we don't have to start our server locally