### PR TITLE
Add markdown view

### DIFF
--- a/Annotato/Annotato/HTTP/URLSessionHTTPService.swift
+++ b/Annotato/Annotato/HTTP/URLSessionHTTPService.swift
@@ -42,6 +42,20 @@ struct URLSessionHTTPService: AnnotatoHTTPService {
         return data
     }
 
+    func postMarkdown(url: String, data: Data) async throws -> Data {
+        guard let url = URL(string: url) else {
+            throw AnnotatoHTTPError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = AnnotatoHTTPMethod.post.rawValue
+        request.setValue("text/markdown", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return data
+    }
+
     func put(url: String, data: Data) async throws -> Data {
         guard let url = URL(string: url) else {
             throw AnnotatoHTTPError.invalidURL

--- a/Annotato/Annotato/Info.plist
+++ b/Annotato/Annotato/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>

--- a/Annotato/Annotato/ViewModels/Sample/SampleData.swift
+++ b/Annotato/Annotato/ViewModels/Sample/SampleData.swift
@@ -95,7 +95,7 @@ class SampleData {
             ),
             AnnotationMarkdownViewModel(
                 id: UUID(),
-                content: "some markdown",
+                content: "# hello\nsome `code`\n\nabcd",
                 width: 300.0,
                 height: 30.0
             ),

--- a/Annotato/Annotato/ViewModels/Sample/SampleData.swift
+++ b/Annotato/Annotato/ViewModels/Sample/SampleData.swift
@@ -95,7 +95,7 @@ class SampleData {
             ),
             AnnotationMarkdownViewModel(
                 id: UUID(),
-                content: "# hello\nsome `code`\n\nabcd",
+                content: "# hello\nsome `code`\n\nabcd\n\na long string that exceeds the width of the container",
                 width: 300.0,
                 height: 30.0
             ),

--- a/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
+++ b/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
@@ -2,9 +2,9 @@ import WebKit
 
 // References: https://stackoverflow.com/questions/45998220/the-font-looks-like-smaller-in-wkwebview-than-in-uiwebview
 extension WKWebView {
-    /// load HTML String same font like the UIWebview
+    /// Load HTML String same font like the UIWebview
     ///
-    //// - Parameters:
+    /// - Parameters:
     ///   - content: HTML content which we need to load in the webview.
     ///   - baseURL: Content base url. It is optional.
     func loadHTMLStringWithCorrectScale(content: String, baseURL: URL?) {

--- a/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
+++ b/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
@@ -1,0 +1,18 @@
+import WebKit
+
+// References: https://stackoverflow.com/questions/45998220/the-font-looks-like-smaller-in-wkwebview-than-in-uiwebview
+extension WKWebView {
+    /// load HTML String same font like the UIWebview
+    ///
+    //// - Parameters:
+    ///   - content: HTML content which we need to load in the webview.
+    ///   - baseURL: Content base url. It is optional.
+    func loadHTMLStringWithCorrectScale(content: String, baseURL: URL?) {
+        let headerString =
+            """
+            <header><meta name='viewport' content='width=device-width,
+            initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'></header>
+            """
+        loadHTMLString(headerString + content, baseURL: baseURL)
+    }
+}

--- a/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
+++ b/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
@@ -15,4 +15,12 @@ extension WKWebView {
             """
         loadHTMLString(headerString + content, baseURL: baseURL)
     }
+
+    func changeFont(fontFamilies: String) {
+        let changeFontFamilyScript =
+            """
+            document.getElementsByTagName(\'body\')[0].style.fontFamily = \"\(fontFamilies)\";
+            """
+        evaluateJavaScript(changeFontFamilyScript)
+    }
 }

--- a/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
+++ b/Annotato/Annotato/Views/Components/Extensions/WKWebView.swift
@@ -8,12 +8,21 @@ extension WKWebView {
     ///   - content: HTML content which we need to load in the webview.
     ///   - baseURL: Content base url. It is optional.
     func loadHTMLStringWithCorrectScale(content: String, baseURL: URL?) {
-        let headerString =
+        let rawHtmlString =
             """
-            <header><meta name='viewport' content='width=device-width,
-            initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'></header>
+            <html lang="en">
+                <head>
+                    <meta name='viewport' content='width=device-width,
+                          initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0,
+                          user-scalable=no'>
+                </head>
+
+                <body>
+                    \(content)
+                </body>
+            </html>
             """
-        loadHTMLString(headerString + content, baseURL: baseURL)
+        loadHTMLString(rawHtmlString, baseURL: baseURL)
     }
 
     func changeFont(fontFamilies: String) {

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
@@ -22,12 +22,12 @@ class AnnotationMarkdownView: UIView, AnnotationPartView {
         self.isEditable = false
         super.init(frame: viewModel.frame)
 
-        switchView(basedOn: viewModel.isEditing)
-        setUpEditView()
         setUpPreviewView()
-        setUpSubscribers()
+        setUpEditView()
         setUpStyle()
+        setUpSubscribers()
         addGestureRecognizers()
+        switchView(basedOn: viewModel.isEditing)
     }
 
     private func setUpEditView() {
@@ -59,8 +59,8 @@ class AnnotationMarkdownView: UIView, AnnotationPartView {
             editView.removeFromSuperview()
             previewView.removeFromSuperview()
             isEditable = false
-            loadMarkdown()
             addSubview(previewView)
+            loadMarkdown()
         }
     }
 
@@ -102,8 +102,12 @@ extension AnnotationMarkdownView: UITextViewDelegate {
 }
 
 extension AnnotationMarkdownView: WKNavigationDelegate {
+    // References: https://stackoverflow.com/questions/27850792/uiwebview-dynamic-content-size
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         webView.frame.size = CGSize(width: frame.width, height: webView.scrollView.contentSize.height)
+        webView.changeFont(fontFamilies: "-apple-system, BlinkMacSystemFont, sans-serif")
+        webView.contentMode = .scaleAspectFit
+        webView.sizeToFit()
         changeSize(to: webView.frame.size)
     }
 

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
@@ -47,17 +47,16 @@ class AnnotationMarkdownView: UIView, AnnotationPartView {
     }
 
     private func switchView(basedOn isEditing: Bool) {
+        editView.removeFromSuperview()
+        previewView.removeFromSuperview()
+
         if isEditing {
-            editView.removeFromSuperview()
-            previewView.removeFromSuperview()
             isEditable = true
             editView.text = viewModel.content
             addSubview(editView)
             editView.resizeFrameToFitContent()
             changeSize(to: editView.frame.size)
         } else {
-            editView.removeFromSuperview()
-            previewView.removeFromSuperview()
             isEditable = false
             addSubview(previewView)
             loadMarkdown()


### PR DESCRIPTION
- Markdown view is shown by making an api call to https://pandoc.bilimedtech.com/html to get HTML
- The HTML is rendered with `WKWebView`

Problem
- WKWebView doesn't seem to load on the simulator, but it works on iPad. I'm not sure if it's my settings or something.
- WKWebView fails to load sometimes. I can't find a way around it yet. The easiest way is to reload by just tapping the edit button and then the view button again.
<img width="102" alt="Screenshot 2022-03-20 at 2 19 13 PM" src="https://user-images.githubusercontent.com/71375383/159150736-a4421f39-2435-429f-9cf5-81e7bb5c1670.png">
For example here, `webView.loadHTML` was called 4 times. But it only finished 3 times. I used their method to listen to failures, but that was not called either ("did fail" is not printed)
<img width="477" alt="Screenshot 2022-03-20 at 2 20 22 PM" src="https://user-images.githubusercontent.com/71375383/159150754-23a7a8be-a319-4e13-a952-1301bd4c2371.png">


- Also I realised if we delete a section in the middle if the adjacent parts are suddenly of the same type, we should merge them together? But not so important for now.
