### PR TITLE
Add order property to annotation text

### DIFF
--- a/AnnotatoBackend/Sources/App/Migrations/CreateAnnotationText.swift
+++ b/AnnotatoBackend/Sources/App/Migrations/CreateAnnotationText.swift
@@ -8,6 +8,7 @@ struct CreateAnnotationText: Migration {
             .field("type", .int, .required)
             .field("content", .string, .required)
             .field("height", .double, .required)
+            .field("order", .int, .required)
             .field("annotation_id", .uuid, .required, .references(AnnotationEntity.schema, "id", onDelete: .cascade))
             .field("created_at", .datetime)
             .field("updated_at", .datetime)

--- a/AnnotatoBackend/Sources/App/Models/AnnotationTextEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/AnnotationTextEntity.swift
@@ -16,6 +16,9 @@ final class AnnotationTextEntity: Model {
     @Field(key: "height")
     var height: Double
 
+    @Field(key: "order")
+    var order: Int
+
     @Parent(key: "annotation_id")
     var annotation: AnnotationEntity
 
@@ -31,6 +34,7 @@ final class AnnotationTextEntity: Model {
         type: AnnotationType,
         content: String,
         height: Double,
+        order: Int,
         annotationId: AnnotationEntity.IDValue,
         id: UUID? = nil
     ) {
@@ -38,6 +42,7 @@ final class AnnotationTextEntity: Model {
         self.type = type.rawValue
         self.content = content
         self.height = height
+        self.order = order
         self.$annotation.id = annotationId
     }
 }
@@ -48,6 +53,7 @@ extension AnnotationTextEntity: PersistedEntity {
             type: model.type,
             content: model.content,
             height: model.height,
+            order: model.order,
             annotationId: model.annotationId,
             id: model.id
         )

--- a/AnnotatoBackend/Sources/App/Persistence/SharedLibraryModels+Persistable/AnnotationText+Persistable.swift
+++ b/AnnotatoBackend/Sources/App/Persistence/SharedLibraryModels+Persistable/AnnotationText+Persistable.swift
@@ -8,6 +8,7 @@ extension AnnotationText: Persistable {
             type: AnnotationType(rawValue: managedEntity.type) ?? .plainText,
             content: managedEntity.content,
             height: managedEntity.height,
+            order: managedEntity.order,
             annotationId: managedEntity.$annotation.id,
             id: managedEntity.id
         )

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationText.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationText.swift
@@ -5,12 +5,14 @@ public final class AnnotationText: Codable {
     public let type: AnnotationType
     public private(set) var content: String
     public private(set) var height: Double
+    public private(set) var order: Int
     public let annotationId: UUID
 
     public required init(
         type: AnnotationType,
         content: String,
         height: Double,
+        order: Int,
         annotationId: UUID,
         id: UUID? = nil
     ) {
@@ -18,6 +20,7 @@ public final class AnnotationText: Codable {
         self.type = type
         self.content = content
         self.height = height
+        self.order = order
         self.annotationId = annotationId
     }
 }
@@ -25,6 +28,6 @@ public final class AnnotationText: Codable {
 extension AnnotationText: CustomDebugStringConvertible {
     public var debugDescription: String {
         "AnnotationText(id: \(id), type: \(type), content: \(content), " +
-        "height: \(height), annotationId: \(annotationId))"
+        "height: \(height), order: \(order), annotationId: \(annotationId))"
     }
 }


### PR DESCRIPTION
This property is required so that we preserve the order in which they appear in the annotation stack.