### PR TITLE
Move swiftlint to base directory

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Run SwiftLint with --strict
         uses: norio-nomura/action-swiftlint@3.2.1
         with:
-          args: --config Annotato/.swiftlint.yml --strict
+          args: --config .swiftlint.yml --strict

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 excluded:
-  - Pods
+  - Annotato/Pods
+  - AnnotatoBackend/.build
 
 opt_in_rules:
   - anyobject_protocol


### PR DESCRIPTION
So that we can run swiftlint from the base directory to lint files in the `AnnotatoBackend` and `AnnotatoSharedLibrary` packages too