### PR TITLE
Integrate saving of document with annotations

### DIFF
--- a/Annotato/Annotato/API/BaseAPI.swift
+++ b/Annotato/Annotato/API/BaseAPI.swift
@@ -2,5 +2,5 @@ struct BaseAPI {
     private static let localApiEndpoint = "http://127.0.0.1:8080"
     private static let remoteApiEndpoint = "http://178.128.111.22:80"
 
-    static let baseAPIUrl = remoteApiEndpoint
+    static let baseAPIUrl = localApiEndpoint
 }

--- a/Annotato/Annotato/API/BaseAPI.swift
+++ b/Annotato/Annotato/API/BaseAPI.swift
@@ -2,5 +2,5 @@ struct BaseAPI {
     private static let localApiEndpoint = "http://127.0.0.1:8080"
     private static let remoteApiEndpoint = "http://178.128.111.22:80"
 
-    static let baseAPIUrl = localApiEndpoint
+    static let baseAPIUrl = remoteApiEndpoint
 }

--- a/Annotato/Annotato/Controllers/DocumentController.swift
+++ b/Annotato/Annotato/Controllers/DocumentController.swift
@@ -18,4 +18,13 @@ struct DocumentController {
 
         return DocumentViewModel(model: document)
     }
+
+    static func updateDocument(document: DocumentViewModel) async -> DocumentViewModel? {
+        let updatedDocument = await DocumentsAPI().updateDocument(document: document.model)
+        guard let updatedDocument = updatedDocument else {
+            return nil
+        }
+
+        return DocumentViewModel(model: updatedDocument)
+    }
 }

--- a/Annotato/Annotato/Controllers/DocumentController.swift
+++ b/Annotato/Annotato/Controllers/DocumentController.swift
@@ -19,7 +19,7 @@ struct DocumentController {
         return DocumentViewModel(model: document)
     }
 
-    static func updateDocument(document: DocumentViewModel) async -> DocumentViewModel? {
+    @discardableResult static func updateDocument(document: DocumentViewModel) async -> DocumentViewModel? {
         let updatedDocument = await DocumentsAPI().updateDocument(document: document.model)
         guard let updatedDocument = updatedDocument else {
             return nil

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationPaletteViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationPaletteViewModel.swift
@@ -13,7 +13,6 @@ class AnnotationPaletteViewModel: ObservableObject {
     private(set) var width: Double
     private(set) var height: Double
 
-    private var isMinimizedByUser = true
     @Published var isMinimized = true
 
     @Published var isEditing = false {
@@ -70,18 +69,11 @@ class AnnotationPaletteViewModel: ObservableObject {
     func enterEditMode() {
         isEditing = true
         parentViewModel?.enterEditMode()
-        enterMaximizedMode()
     }
 
     func enterViewMode() {
         isEditing = false
         parentViewModel?.enterViewMode()
-
-        guard isMinimizedByUser else {
-            return
-        }
-
-        enterMinimizedMode()
     }
 
     func didSelectDeleteButton() {
@@ -89,8 +81,6 @@ class AnnotationPaletteViewModel: ObservableObject {
     }
 
     func didSelectMinimizeOrMaximizeButton() {
-        isMinimizedByUser.toggle()
-
         let isNowMinimized = !isMinimized
         if isNowMinimized {
             enterMinimizedMode()

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationViewModel.swift
@@ -6,6 +6,8 @@ import AnnotatoSharedLibrary
 import Combine
 
 class AnnotationViewModel: ObservableObject {
+    private weak var document: DocumentViewModel?
+
     private(set) var model: Annotation
     private var cancellables: Set<AnyCancellable> = []
 
@@ -25,8 +27,9 @@ class AnnotationViewModel: ObservableObject {
     @Published private(set) var isRemoved = false
     @Published private(set) var isMinimized = true
 
-    init(model: Annotation, palette: AnnotationPaletteViewModel? = nil) {
+    init(model: Annotation, document: DocumentViewModel, palette: AnnotationPaletteViewModel? = nil) {
         self.model = model
+        self.document = document
         self.palette = palette ?? AnnotationPaletteViewModel(
             origin: .zero, width: model.width, height: 50.0)
         self.parts = []
@@ -230,5 +233,6 @@ extension AnnotationViewModel {
 extension AnnotationViewModel {
     func didDelete() {
         isRemoved = true
+        document?.removeAnnotation(annotation: self)
     }
 }

--- a/Annotato/Annotato/ViewModels/Document/DocumentViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentViewModel.swift
@@ -55,6 +55,6 @@ extension DocumentViewModel {
 
     func removeAnnotation(annotation: AnnotationViewModel) {
         model.removeAnnotation(annotation: annotation.model)
-        annotations.removeAll(where: { $0 === annotation })
+        annotations.removeAll(where: { $0.model.id == annotation.model.id })
     }
 }

--- a/Annotato/Annotato/ViewModels/Document/DocumentViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentViewModel.swift
@@ -6,20 +6,19 @@ import Combine
 class DocumentViewModel: ObservableObject {
     let model: Document
 
-    private(set) var annotations: [AnnotationViewModel]
+    private(set) var annotations: [AnnotationViewModel] = []
     private(set) var pdfDocument: PdfViewModel
 
     @Published private(set) var addedAnnotation: AnnotationViewModel?
 
     init?(model: Document) {
-        self.model = model
-        self.annotations = model.annotations.map { AnnotationViewModel(model: $0) }
-
         guard let baseFileUrl = URL(string: model.baseFileUrl) else {
             return nil
         }
 
+        self.model = model
         self.pdfDocument = PdfViewModel(baseFileUrl: baseFileUrl)
+        self.annotations = model.annotations.map { AnnotationViewModel(model: $0, document: self) }
     }
 }
 
@@ -40,7 +39,7 @@ extension DocumentViewModel {
         )
         model.addAnnotation(annotation: newAnnotation)
 
-        let annotationViewModel = AnnotationViewModel(model: newAnnotation)
+        let annotationViewModel = AnnotationViewModel(model: newAnnotation, document: self)
         annotationViewModel.center = center
 
         if annotationViewModel.hasExceededBounds(bounds: bounds) {
@@ -52,5 +51,10 @@ extension DocumentViewModel {
         annotationViewModel.enterMaximizedMode()
         annotations.append(annotationViewModel)
         addedAnnotation = annotationViewModel
+    }
+
+    func removeAnnotation(annotation: AnnotationViewModel) {
+        model.removeAnnotation(annotation: annotation.model)
+        annotations.removeAll(where: { $0 === annotation })
     }
 }

--- a/Annotato/Annotato/ViewModels/Document/DocumentViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentViewModel.swift
@@ -4,7 +4,7 @@ import AnnotatoSharedLibrary
 import Combine
 
 class DocumentViewModel: ObservableObject {
-    private let model: Document
+    let model: Document
 
     private(set) var annotations: [AnnotationViewModel]
     private(set) var pdfDocument: PdfViewModel

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -104,16 +104,16 @@ extension AnnotationPaletteView {
 
     @objc
     private func didTapEditOrViewButton(_ button: UIButton) {
-        if editOrViewButton.isSelected {
-            editOrViewButton.isSelected = false
-            viewModel.enterViewMode()
+        editOrViewButton.isSelected.toggle()
 
-            viewModel.enterMinimizedMode()
-        } else {
-            editOrViewButton.isSelected = true
+        let isNowEditing = editOrViewButton.isSelected
+
+        if isNowEditing {
             viewModel.enterEditMode()
-
             viewModel.enterMaximizedMode()
+        } else {
+            viewModel.enterViewMode()
+            viewModel.enterMinimizedMode()
         }
     }
 
@@ -124,12 +124,14 @@ extension AnnotationPaletteView {
 
     @objc
     private func didTapMinimizeOrMaximizeButton(_ button: UIButton) {
-        if minimizeOrMaximizeButton.isSelected {
-            minimizeOrMaximizeButton.isSelected = false
-            viewModel.enterMaximizedMode()
-        } else {
-            minimizeOrMaximizeButton.isSelected = true
+        minimizeOrMaximizeButton.isSelected.toggle()
+
+        let isNowMinimized = minimizeOrMaximizeButton.isSelected
+
+        if isNowMinimized {
             viewModel.enterMinimizedMode()
+        } else {
+            viewModel.enterMaximizedMode()
         }
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -107,7 +107,6 @@ extension AnnotationPaletteView {
         editOrViewButton.isSelected.toggle()
 
         let isNowEditing = editOrViewButton.isSelected
-
         if isNowEditing {
             viewModel.enterEditMode()
             viewModel.enterMaximizedMode()
@@ -127,7 +126,6 @@ extension AnnotationPaletteView {
         minimizeOrMaximizeButton.isSelected.toggle()
 
         let isNowMinimized = minimizeOrMaximizeButton.isSelected
-
         if isNowMinimized {
             viewModel.enterMinimizedMode()
         } else {

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -113,6 +113,7 @@ extension AnnotationPaletteView {
         let isNowEditing = editOrViewButton.isSelected
         if isNowEditing {
             viewModel.enterEditMode()
+            viewModel.enterMaximizedMode()
         } else {
             viewModel.enterViewMode()
         }

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -79,6 +79,10 @@ class AnnotationPaletteView: UIToolbar {
             self?.editOrViewButton.isSelected = isEditing
             self?.minimizeOrMaximizeButton.isHidden = isEditing
         }).store(in: &cancellables)
+
+        viewModel.$isMinimized.sink(receiveValue: { [weak self] isMinimized in
+            self?.minimizeOrMaximizeButton.isSelected = isMinimized
+        }).store(in: &cancellables)
     }
 }
 
@@ -109,10 +113,8 @@ extension AnnotationPaletteView {
         let isNowEditing = editOrViewButton.isSelected
         if isNowEditing {
             viewModel.enterEditMode()
-            viewModel.enterMaximizedMode()
         } else {
             viewModel.enterViewMode()
-            viewModel.enterMinimizedMode()
         }
     }
 
@@ -123,13 +125,6 @@ extension AnnotationPaletteView {
 
     @objc
     private func didTapMinimizeOrMaximizeButton(_ button: UIButton) {
-        minimizeOrMaximizeButton.isSelected.toggle()
-
-        let isNowMinimized = minimizeOrMaximizeButton.isSelected
-        if isNowMinimized {
-            viewModel.enterMinimizedMode()
-        } else {
-            viewModel.enterMaximizedMode()
-        }
+        viewModel.didSelectMinimizeOrMaximizeButton()
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -77,6 +77,7 @@ class AnnotationPaletteView: UIToolbar {
             self?.textButton.isHidden = !isEditing
             self?.markdownButton.isHidden = !isEditing
             self?.editOrViewButton.isSelected = isEditing
+            self?.minimizeOrMaximizeButton.isHidden = isEditing
         }).store(in: &cancellables)
     }
 }
@@ -106,9 +107,13 @@ extension AnnotationPaletteView {
         if editOrViewButton.isSelected {
             editOrViewButton.isSelected = false
             viewModel.enterViewMode()
+
+            viewModel.enterMinimizedMode()
         } else {
             editOrViewButton.isSelected = true
             viewModel.enterEditMode()
+
+            viewModel.enterMaximizedMode()
         }
     }
 

--- a/Annotato/Annotato/Views/Document/Edit/DocumentEditViewController.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentEditViewController.swift
@@ -77,7 +77,7 @@ class DocumentEditViewController: UIViewController, AlertPresentable, SpinnerPre
                 return
             }
 
-            self.documentViewModel = await DocumentController.updateDocument(document: documentViewModel)
+            await DocumentController.updateDocument(document: documentViewModel)
         }
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/DocumentEditViewController.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentEditViewController.swift
@@ -70,10 +70,21 @@ class DocumentEditViewController: UIViewController, AlertPresentable, SpinnerPre
         documentView.leftAnchor.constraint(equalTo: margins.leftAnchor).isActive = true
         documentView.rightAnchor.constraint(equalTo: margins.rightAnchor).isActive = true
     }
+
+    private func saveDocument() {
+        Task {
+            guard let documentViewModel = documentViewModel else {
+                return
+            }
+
+            self.documentViewModel = await DocumentController.updateDocument(document: documentViewModel)
+        }
+    }
 }
 
 extension DocumentEditViewController: DocumentEditToolbarDelegate, Navigable {
     func didTapBackButton() {
+        saveDocument()
         goBack()
     }
 }

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -6,6 +6,7 @@ struct DocumentsDataAccess {
     static func list(db: Database, userId: String) async throws -> [Document] {
         let documentEntities = try await DocumentEntity.query(on: db)
             .filter(\.$ownerId == userId)
+            .sort(\.$name)
             .all().get()
 
         for documentEntity in documentEntities {


### PR DESCRIPTION
Changes
- Document is now saved together with the annotations when one navigates out of the document edit view
- Maximise annotations when editing
- Sort documents by name asc in list page

Closes #43 