### PR TITLE
Add handwriting annotations

### DIFF
--- a/Annotato/Annotato/Enums/ImageName.swift
+++ b/Annotato/Annotato/Enums/ImageName.swift
@@ -8,6 +8,7 @@ enum SystemImageName: String {
     case eye
     case mSquare = "m.square"
     case people = "person.2.fill"
+    case scribble
     case pencil
     case share = "arrowshape.turn.up.forward"
     case textformat

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
@@ -27,8 +27,8 @@ class AnnotationHandwritingViewModel: AnnotationPartViewModel {
         }).store(in: &cancellables)
     }
 
-    func setHandwriting(to newHandwriting: Data) {
-        handwritingModel.setHandwriting(to: newHandwriting)
+    func setHandwritingDrawing(to newHandwritingDrawing: PKDrawing) {
+        handwritingModel.setHandwriting(to: newHandwritingDrawing.dataRepresentation())
     }
 
     override func toView() -> AnnotationPartView {

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+import CoreGraphics
+import Combine
+import AnnotatoSharedLibrary
+import PencilKit
+
+class AnnotationHandwritingViewModel: AnnotationPartViewModel, ObservableObject {
+    weak var parentViewModel: AnnotationViewModel?
+
+    private(set) var model: AnnotationPart
+    private(set) var origin: CGPoint
+    private(set) var width: Double
+    private var cancellables: Set<AnyCancellable> = []
+
+    var handwritingModel: AnnotationHandwriting? {
+        model as? AnnotationHandwriting
+    }
+    var id: UUID {
+        model.id
+    }
+    var height: Double {
+        model.height
+    }
+    var handwriting: Data {
+        handwritingModel?.handwriting ?? Data()
+    }
+    var handwritingDrawing: PKDrawing {
+        (try? PKDrawing(data: handwriting)) ?? PKDrawing()
+    }
+
+    @Published private(set) var isEditing = false
+    @Published private(set) var isRemoved = false
+    @Published var isSelected = false
+
+    init(model: AnnotationHandwriting, width: Double, origin: CGPoint = .zero) {
+        self.model = model
+        self.width = width
+        self.origin = origin
+
+        setUpSubscribers()
+    }
+
+    func toView() -> AnnotationPartView {
+        AnnotationHandwritingView(viewModel: self)
+    }
+
+    func enterEditMode() {
+        isEditing = true
+    }
+
+    func enterViewMode() {
+        isEditing = false
+    }
+
+    func setHandwriting(to newHandwriting: Data) {
+        handwritingModel?.setHandwriting(to: newHandwriting)
+    }
+
+    private func setUpSubscribers() {
+        handwritingModel?.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
+            self?.isRemoved = isRemoved
+        }).store(in: &cancellables)
+    }
+}
+
+extension AnnotationHandwritingViewModel {
+    var editFrame: CGRect {
+        CGRect(x: .zero, y: .zero, width: width, height: model.height)
+    }
+}

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
@@ -4,67 +4,34 @@ import Combine
 import AnnotatoSharedLibrary
 import PencilKit
 
-class AnnotationHandwritingViewModel: AnnotationPartViewModel, ObservableObject {
-    weak var parentViewModel: AnnotationViewModel?
+class AnnotationHandwritingViewModel: AnnotationPartViewModel {
+    var handwritingModel: AnnotationHandwriting
 
-    private(set) var model: AnnotationPart
-    private(set) var origin: CGPoint
-    private(set) var width: Double
-    private var cancellables: Set<AnyCancellable> = []
-
-    var handwritingModel: AnnotationHandwriting? {
-        model as? AnnotationHandwriting
-    }
-    var id: UUID {
-        model.id
-    }
-    var height: Double {
-        model.height
-    }
     var handwriting: Data {
-        handwritingModel?.handwriting ?? Data()
+        handwritingModel.handwriting
     }
     var handwritingDrawing: PKDrawing {
         (try? PKDrawing(data: handwriting)) ?? PKDrawing()
     }
 
-    @Published private(set) var isEditing = false
-    @Published private(set) var isRemoved = false
-    @Published var isSelected = false
-
     init(model: AnnotationHandwriting, width: Double, origin: CGPoint = .zero) {
-        self.model = model
-        self.width = width
-        self.origin = origin
+        self.handwritingModel = model
+        super.init(model: model, width: width, origin: origin)
 
         setUpSubscribers()
     }
 
-    func toView() -> AnnotationPartView {
-        AnnotationHandwritingView(viewModel: self)
-    }
-
-    func enterEditMode() {
-        isEditing = true
-    }
-
-    func enterViewMode() {
-        isEditing = false
-    }
-
-    func setHandwriting(to newHandwriting: Data) {
-        handwritingModel?.setHandwriting(to: newHandwriting)
-    }
-
     private func setUpSubscribers() {
-        handwritingModel?.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
+        handwritingModel.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
             self?.isRemoved = isRemoved
         }).store(in: &cancellables)
     }
-}
 
-extension AnnotationHandwritingViewModel {
-    var editFrame: CGRect {
-        CGRect(x: .zero, y: .zero, width: width, height: model.height)
+    func setHandwriting(to newHandwriting: Data) {
+        handwritingModel.setHandwriting(to: newHandwriting)
+    }
+
+    override func toView() -> AnnotationPartView {
+        AnnotationHandwritingView(viewModel: self)
     }
 }

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationHandwritingViewModel.swift
@@ -5,13 +5,10 @@ import AnnotatoSharedLibrary
 import PencilKit
 
 class AnnotationHandwritingViewModel: AnnotationPartViewModel {
-    var handwritingModel: AnnotationHandwriting
+    private var handwritingModel: AnnotationHandwriting
 
-    var handwriting: Data {
-        handwritingModel.handwriting
-    }
     var handwritingDrawing: PKDrawing {
-        (try? PKDrawing(data: handwriting)) ?? PKDrawing()
+        (try? PKDrawing(data: handwritingModel.handwriting)) ?? PKDrawing()
     }
 
     init(model: AnnotationHandwriting, width: Double, origin: CGPoint = .zero) {

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationMarkdownViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationMarkdownViewModel.swift
@@ -3,64 +3,32 @@ import CoreGraphics
 import Combine
 import AnnotatoSharedLibrary
 
-class AnnotationMarkdownViewModel: AnnotationPartViewModel, ObservableObject {
-    weak var parentViewModel: AnnotationViewModel?
+class AnnotationMarkdownViewModel: AnnotationPartViewModel {
+    var textModel: AnnotationText
 
-    private(set) var model: AnnotationPart
-    private(set) var origin: CGPoint
-    private(set) var width: Double
-    private var cancellables: Set<AnyCancellable> = []
-
-    // TODO: To use abstract class
-    var textModel: AnnotationText? {
-        model as? AnnotationText
-    }
-    var id: UUID {
-        model.id
-    }
-    var height: Double {
-        model.height
-    }
     var content: String {
-        textModel?.content ?? ""
+        textModel.content
     }
-
-    @Published private(set) var isEditing = false
-    @Published private(set) var isRemoved = false
-    @Published var isSelected = false
 
     init(model: AnnotationText, width: Double, origin: CGPoint = .zero) {
-        self.model = model
-        self.width = width
-        self.origin = origin
+        self.textModel = model
+        super.init(model: model, width: width, origin: origin)
 
         setUpSubscribers()
     }
 
-    func toView() -> AnnotationPartView {
-        AnnotationMarkdownView(viewModel: self)
-    }
-
-    func enterEditMode() {
-        isEditing = true
-    }
-
-    func enterViewMode() {
-        isEditing = false
+    private func setUpSubscribers() {
+        textModel.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
+            self?.isRemoved = isRemoved
+        }).store(in: &cancellables)
     }
 
     func setContent(to newContent: String) {
-        textModel?.setContent(to: newContent)
+        textModel.setContent(to: newContent)
     }
 
-    func remove() {
-        isRemoved = true
-    }
-
-    private func setUpSubscribers() {
-        textModel?.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
-            self?.isRemoved = isRemoved
-        }).store(in: &cancellables)
+    override func toView() -> AnnotationPartView {
+        AnnotationMarkdownView(viewModel: self)
     }
 }
 

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationMarkdownViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationMarkdownViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 import AnnotatoSharedLibrary
 
 class AnnotationMarkdownViewModel: AnnotationPartViewModel {
-    var textModel: AnnotationText
+    private var textModel: AnnotationText
 
     var content: String {
         textModel.content

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationPaletteViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationPaletteViewModel.swift
@@ -27,6 +27,7 @@ class AnnotationPaletteViewModel: ObservableObject {
         didSet {
             if textIsSelected {
                 markdownIsSelected = false
+                handwritingIsSelected = false
             }
         }
     }
@@ -34,6 +35,15 @@ class AnnotationPaletteViewModel: ObservableObject {
         didSet {
             if markdownIsSelected {
                 textIsSelected = false
+                handwritingIsSelected = false
+            }
+        }
+    }
+    @Published private(set) var handwritingIsSelected = false {
+        didSet {
+            if handwritingIsSelected {
+                textIsSelected = false
+                markdownIsSelected = false
             }
         }
     }
@@ -64,6 +74,14 @@ class AnnotationPaletteViewModel: ObservableObject {
         }
         markdownIsSelected = true
         parentViewModel?.appendMarkdownPartIfNecessary()
+    }
+
+    func didSelectHandwritingButton() {
+        guard parentViewModel?.isEditing ?? false else {
+            return
+        }
+        handwritingIsSelected = true
+        parentViewModel?.appendHandwritingPartIfNecessary()
     }
 
     func enterEditMode() {
@@ -104,6 +122,10 @@ class AnnotationPaletteViewModel: ObservableObject {
 
         if selectedPart is AnnotationMarkdownViewModel {
             markdownIsSelected = true
+        }
+
+        if selectedPart is AnnotationHandwritingViewModel {
+            handwritingIsSelected = true
         }
     }
 }

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationPaletteViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationPaletteViewModel.swift
@@ -116,16 +116,15 @@ class AnnotationPaletteViewModel: ObservableObject {
     }
 
     func updatePalette(basedOn selectedPart: AnnotationPartViewModel) {
-        if selectedPart is AnnotationTextViewModel {
+        switch selectedPart {
+        case is AnnotationTextViewModel:
             textIsSelected = true
-        }
-
-        if selectedPart is AnnotationMarkdownViewModel {
+        case is AnnotationMarkdownViewModel:
             markdownIsSelected = true
-        }
-
-        if selectedPart is AnnotationHandwritingViewModel {
+        case is AnnotationHandwritingViewModel:
             handwritingIsSelected = true
+        default:
+            return
         }
     }
 }

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationPartViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationPartViewModel.swift
@@ -1,19 +1,45 @@
-import CoreGraphics
 import Foundation
+import CoreGraphics
+import Combine
 import AnnotatoSharedLibrary
 
-protocol AnnotationPartViewModel: AnyObject {
-    var parentViewModel: AnnotationViewModel? { get set }
-    var model: AnnotationPart { get }
-    var id: UUID { get }
-    var origin: CGPoint { get }
-    var width: Double { get }
-    var height: Double { get }
-    var isSelected: Bool { get set }
+class AnnotationPartViewModel: ObservableObject {
+    weak var parentViewModel: AnnotationViewModel?
 
-    func toView() -> AnnotationPartView
-    func enterEditMode()
-    func enterViewMode()
+    var cancellables: Set<AnyCancellable> = []
+
+    var model: AnnotationPart
+    var origin: CGPoint
+    var width: Double
+    var id: UUID {
+        model.id
+    }
+    var height: Double {
+        model.height
+    }
+
+    @Published var isEditing = false
+    @Published var isSelected = false
+    @Published var isRemoved = false
+
+    init(model: AnnotationPart, width: Double, origin: CGPoint = .zero) {
+        self.model = model
+        self.width = width
+        self.origin = origin
+    }
+
+    func enterEditMode() {
+        isEditing = true
+    }
+
+    func enterViewMode() {
+        isEditing = false
+    }
+
+    // swiftlint:disable:next unavailable_function
+    func toView() -> AnnotationPartView {
+        fatalError("This method should be overridden by a concrete subclass")
+    }
 }
 
 extension AnnotationPartViewModel {

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationPartViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationPartViewModel.swift
@@ -57,6 +57,10 @@ extension AnnotationPartViewModel {
     }
 
     func didSelect() {
+        guard !isSelected else {
+            return
+        }
+
         parentViewModel?.setSelectedPart(to: self)
     }
 }

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationTextViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationTextViewModel.swift
@@ -3,59 +3,31 @@ import CoreGraphics
 import Combine
 import AnnotatoSharedLibrary
 
-class AnnotationTextViewModel: AnnotationPartViewModel, ObservableObject {
-    weak var parentViewModel: AnnotationViewModel?
+class AnnotationTextViewModel: AnnotationPartViewModel {
+    var textModel: AnnotationText
 
-    private(set) var model: AnnotationPart
-    private(set) var origin: CGPoint
-    private(set) var width: Double
-    private var cancellables: Set<AnyCancellable> = []
-
-    // TODO: To use abstract class
-    var textModel: AnnotationText? {
-        model as? AnnotationText
-    }
-    var id: UUID {
-        model.id
-    }
-    var height: Double {
-        model.height
-    }
     var content: String {
-        textModel?.content ?? ""
+        textModel.content
     }
-
-    @Published private(set) var isEditing = false
-    @Published private(set) var isRemoved = false
-    @Published var isSelected = false
 
     init(model: AnnotationText, width: Double, origin: CGPoint = .zero) {
-        self.model = model
-        self.width = width
-        self.origin = origin
+        self.textModel = model
+        super.init(model: model, width: width, origin: origin)
 
         setUpSubscribers()
     }
 
-    func toView() -> AnnotationPartView {
-        AnnotationTextView(viewModel: self)
-    }
-
-    func enterEditMode() {
-        isEditing = true
-    }
-
-    func enterViewMode() {
-        isEditing = false
+    private func setUpSubscribers() {
+        textModel.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
+            self?.isRemoved = isRemoved
+        }).store(in: &cancellables)
     }
 
     func setContent(to newContent: String) {
-        textModel?.setContent(to: newContent)
+        textModel.setContent(to: newContent)
     }
 
-    private func setUpSubscribers() {
-        textModel?.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
-            self?.isRemoved = isRemoved
-        }).store(in: &cancellables)
+    override func toView() -> AnnotationPartView {
+        AnnotationTextView(viewModel: self)
     }
 }

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationTextViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationTextViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 import AnnotatoSharedLibrary
 
 class AnnotationTextViewModel: AnnotationPartViewModel {
-    var textModel: AnnotationText
+    private var textModel: AnnotationText
 
     var content: String {
         textModel.content

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationViewModel.swift
@@ -76,6 +76,13 @@ class AnnotationViewModel: ObservableObject {
             self?.addMarkdownPart(part: addedMarkdownPart)
         }).store(in: &cancellables)
 
+        model.$addedHandwritingPart.sink(receiveValue: { [weak self] addedHandwritingPart in
+            guard let addedHandwritingPart = addedHandwritingPart else {
+                return
+            }
+            self?.addHandwritingPart(part: addedHandwritingPart)
+        }).store(in: &cancellables)
+
         model.$origin.sink(receiveValue: { [weak self] _ in
             self?.positionDidChange = true
         }).store(in: &cancellables)
@@ -201,6 +208,10 @@ extension AnnotationViewModel {
         model.appendMarkdownPartIfNecessary()
     }
 
+    func appendHandwritingPartIfNecessary() {
+        model.appendHandwritingPartIfNecessary()
+    }
+
     private func addTextPart(part: AnnotationText) {
         let partViewModel = AnnotationTextViewModel(model: part, width: model.width)
         addNewPart(newPart: partViewModel)
@@ -208,6 +219,11 @@ extension AnnotationViewModel {
 
     private func addMarkdownPart(part: AnnotationText) {
         let partViewModel = AnnotationMarkdownViewModel(model: part, width: model.width)
+        addNewPart(newPart: partViewModel)
+    }
+
+    private func addHandwritingPart(part: AnnotationHandwriting) {
+        let partViewModel = AnnotationHandwritingViewModel(model: part, width: model.width)
         addNewPart(newPart: partViewModel)
     }
 

--- a/Annotato/Annotato/ViewModels/Annotation/AnnotationViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Annotation/AnnotationViewModel.swift
@@ -41,17 +41,23 @@ class AnnotationViewModel: ObservableObject {
         self.palette.parentViewModel = self
 
         for part in model.parts {
-            let viewModel: AnnotationPartViewModel
-            if let part = part as? AnnotationText {
-                switch part.type {
+            let partViewModel: AnnotationPartViewModel
+            switch part {
+            case let textPart as AnnotationText:
+                switch textPart.type {
                 case .plainText:
-                    viewModel = AnnotationTextViewModel(model: part, width: model.width)
+                    partViewModel = AnnotationTextViewModel(model: textPart, width: model.width)
                 case .markdown:
-                    viewModel = AnnotationMarkdownViewModel(model: part, width: model.width)
+                    partViewModel = AnnotationMarkdownViewModel(model: textPart, width: model.width)
                 }
-                parts.append(viewModel)
-                viewModel.parentViewModel = self
+            case let handwritingPart as AnnotationHandwriting:
+                partViewModel = AnnotationHandwritingViewModel(model: handwritingPart, width: model.width)
+            default:
+                continue
             }
+
+            partViewModel.parentViewModel = self
+            parts.append(partViewModel)
         }
 
         setUpSubscribers()

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
@@ -20,6 +20,7 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
         self.drawing = viewModel.handwritingDrawing
         setUpSubscribers()
         addGestureRecognizers()
+        self.addAnnotationPartBorders()
     }
 
     private func setUpSubscribers() {

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
@@ -6,6 +6,7 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
     private var viewModel: AnnotationHandwritingViewModel
     private var cancellables: Set<AnyCancellable> = []
     private var customDelegate: AnnotationHandwritingViewDelegate
+    private var toolPicker = PKToolPicker()
 
     @available(*, unavailable)
     required init(coder: NSCoder) {
@@ -18,9 +19,19 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
         super.init(frame: viewModel.frame)
         self.delegate = customDelegate
         self.drawing = viewModel.handwritingDrawing
+        initializeSubviews()
         setUpSubscribers()
         addGestureRecognizers()
         self.addAnnotationPartBorders()
+    }
+
+    private func initializeSubviews() {
+        initializeToolPicker()
+    }
+
+    private func initializeToolPicker() {
+        toolPicker.addObserver(self)
+        toolPicker.setVisible(true, forFirstResponder: self)
     }
 
     private func setUpSubscribers() {
@@ -37,6 +48,7 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
         viewModel.$isSelected.sink(receiveValue: { [weak self] isSelected in
             self?.drawingGestureRecognizer.isEnabled = isSelected
             if isSelected {
+                self?.becomeFirstResponder()
                 self?.showSelected()
             }
         }).store(in: &cancellables)

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
@@ -1,0 +1,49 @@
+import UIKit
+import PencilKit
+import Combine
+
+class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
+    private var viewModel: AnnotationHandwritingViewModel
+    private var cancellables: Set<AnyCancellable> = []
+    private var customDelegate: AnnotationHandwritingViewDelegate
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(viewModel: AnnotationHandwritingViewModel) {
+        self.viewModel = viewModel
+        self.customDelegate = AnnotationHandwritingViewDelegate(viewModel: viewModel)
+        super.init(frame: viewModel.frame)
+        self.delegate = customDelegate
+        self.drawing = viewModel.handwritingDrawing
+        setUpSubscribers()
+    }
+
+    private func setUpSubscribers() {
+        viewModel.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
+            if isRemoved {
+                self?.removeFromSuperview()
+            }
+        }).store(in: &cancellables)
+
+        viewModel.$isSelected.sink(receiveValue: { [weak self] isSelected in
+            if isSelected {
+                self?.showSelected()
+            }
+        }).store(in: &cancellables)
+    }
+}
+
+class AnnotationHandwritingViewDelegate: NSObject, PKCanvasViewDelegate {
+    private var viewModel: AnnotationHandwritingViewModel
+
+    init(viewModel: AnnotationHandwritingViewModel) {
+        self.viewModel = viewModel
+    }
+
+    func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
+        viewModel.setHandwriting(to: canvasView.drawing.dataRepresentation())
+    }
+}

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
@@ -63,6 +63,6 @@ class AnnotationHandwritingViewDelegate: NSObject, PKCanvasViewDelegate {
     }
 
     func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
-        viewModel.setHandwriting(to: canvasView.drawing.dataRepresentation())
+        viewModel.setHandwritingDrawing(to: canvasView.drawing)
     }
 }

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
@@ -19,11 +19,12 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
         self.delegate = customDelegate
         self.drawing = viewModel.handwritingDrawing
         setUpSubscribers()
+        addGestureRecognizers()
     }
 
     private func setUpSubscribers() {
         viewModel.$isEditing.sink(receiveValue: { [weak self] isEditing in
-            self?.isUserInteractionEnabled = isEditing
+            self?.drawingGestureRecognizer.isEnabled = isEditing
         }).store(in: &cancellables)
 
         viewModel.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
@@ -33,11 +34,24 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
         }).store(in: &cancellables)
 
         viewModel.$isSelected.sink(receiveValue: { [weak self] isSelected in
-            self?.isUserInteractionEnabled = isSelected
+            self?.drawingGestureRecognizer.isEnabled = isSelected
             if isSelected {
                 self?.showSelected()
             }
         }).store(in: &cancellables)
+    }
+}
+
+// MARK: Gestures
+extension AnnotationHandwritingView {
+    private func addGestureRecognizers() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTap))
+        addGestureRecognizer(tapGestureRecognizer)
+    }
+
+    @objc
+    private func didTap() {
+        viewModel.didSelect()
     }
 }
 

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationHandwritingView.swift
@@ -22,6 +22,10 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
     }
 
     private func setUpSubscribers() {
+        viewModel.$isEditing.sink(receiveValue: { [weak self] isEditing in
+            self?.isUserInteractionEnabled = isEditing
+        }).store(in: &cancellables)
+
         viewModel.$isRemoved.sink(receiveValue: { [weak self] isRemoved in
             if isRemoved {
                 self?.removeFromSuperview()
@@ -29,6 +33,7 @@ class AnnotationHandwritingView: PKCanvasView, AnnotationPartView {
         }).store(in: &cancellables)
 
         viewModel.$isSelected.sink(receiveValue: { [weak self] isSelected in
+            self?.isUserInteractionEnabled = isSelected
             if isSelected {
                 self?.showSelected()
             }

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
@@ -83,6 +83,8 @@ class AnnotationMarkdownView: UIView, AnnotationPartView {
             if isSelected {
                 self?.editView.becomeFirstResponder()
                 self?.editView.showSelected()
+            } else {
+                self?.editView.resignFirstResponder()
             }
         }).store(in: &cancellables)
     }

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationMarkdownView.swift
@@ -42,8 +42,7 @@ class AnnotationMarkdownView: UIView, AnnotationPartView {
     private func setUpStyle() {
         heightConstraint = self.heightAnchor.constraint(equalToConstant: self.frame.height)
         self.heightConstraint.isActive = true
-        self.layer.borderWidth = 0.3
-        self.layer.borderColor = UIColor.lightGray.cgColor
+        self.addAnnotationPartBorders()
     }
 
     private func switchView(basedOn isEditing: Bool) {

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -85,9 +85,7 @@ class AnnotationPaletteView: UIToolbar {
         }).store(in: &cancellables)
 
         viewModel.$isEditing.sink(receiveValue: { [weak self] isEditing in
-            self?.textButton.isHidden = !isEditing
-            self?.markdownButton.isHidden = !isEditing
-            self?.handwritingButton.isHidden = !isEditing
+            self?.annotationTypeButtons.forEach { $0.isHidden = !isEditing }
             self?.editOrViewButton.isSelected = isEditing
             self?.minimizeOrMaximizeButton.isHidden = isEditing
         }).store(in: &cancellables)
@@ -109,16 +107,15 @@ extension AnnotationPaletteView {
             annotationTypeButton.isSelected = false
         }
 
-        if toggleableButton == textButton {
+        switch toggleableButton {
+        case textButton:
             viewModel.didSelectTextButton()
-        }
-
-        if toggleableButton == markdownButton {
+        case markdownButton:
             viewModel.didSelectMarkdownButton()
-        }
-
-        if toggleableButton == handwritingButton {
+        case handwritingButton:
             viewModel.didSelectHandwritingButton()
+        default:
+            return
         }
     }
 

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -5,6 +5,7 @@ class AnnotationPaletteView: UIToolbar {
     private(set) var viewModel: AnnotationPaletteViewModel
     private(set) var textButton: ToggleableButton
     private(set) var markdownButton: ToggleableButton
+    private(set) var handwritingButton: ToggleableButton
     private(set) var editOrViewButton: ImageToggleableButton
     private(set) var deleteButton: UIButton
     private(set) var minimizeOrMaximizeButton: ImageToggleableButton
@@ -22,6 +23,8 @@ class AnnotationPaletteView: UIToolbar {
             systemName: SystemImageName.textformat.rawValue, color: .darkGray)
         self.markdownButton = AnnotationPaletteView.makeToggleableSystemButton(
             systemName: SystemImageName.mSquare.rawValue, color: .darkGray)
+        self.handwritingButton = AnnotationPaletteView.makeToggleableSystemButton(
+            systemName: SystemImageName.pencil.rawValue, color: .darkGray)
         self.editOrViewButton = ImageToggleableButton(
             selectedImage: UIImage(systemName: SystemImageName.eye.rawValue),
             unselectedImage: UIImage(systemName: SystemImageName.pencil.rawValue))
@@ -36,16 +39,18 @@ class AnnotationPaletteView: UIToolbar {
     }
 
     private func setUpButtons() {
-        textButton.addTarget(self, action: #selector(didTap(toggleableButton: )), for: .touchUpInside)
-        markdownButton.addTarget(self, action: #selector(didTap(toggleableButton: )), for: .touchUpInside)
-        editOrViewButton.addTarget(self, action: #selector(didTapEditOrViewButton(_: )), for: .touchUpInside)
-        deleteButton.addTarget(self, action: #selector(didTapDeleteButton(_: )), for: .touchUpInside)
+        textButton.addTarget(self, action: #selector(didTap), for: .touchUpInside)
+        markdownButton.addTarget(self, action: #selector(didTap), for: .touchUpInside)
+        handwritingButton.addTarget(self, action: #selector(didTap), for: .touchUpInside)
+        editOrViewButton.addTarget(self, action: #selector(didTapEditOrViewButton), for: .touchUpInside)
+        deleteButton.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
         minimizeOrMaximizeButton.addTarget(
-            self, action: #selector(didTapMinimizeOrMaximizeButton(_:)), for: .touchUpInside)
+            self, action: #selector(didTapMinimizeOrMaximizeButton), for: .touchUpInside)
         minimizeOrMaximizeButton.imageView?.contentMode = .scaleAspectFit
 
         let textBarButton = UIBarButtonItem(customView: textButton)
         let markdownBarButton = UIBarButtonItem(customView: markdownButton)
+        let handwritingBarButton = UIBarButtonItem(customView: handwritingButton)
         let editOrViewBarButton = UIBarButtonItem(customView: editOrViewButton)
         let deleteBarButton = UIBarButtonItem(customView: deleteButton)
         let minimizeOrMaximizeBarButton = UIBarButtonItem(customView: minimizeOrMaximizeButton)
@@ -55,6 +60,8 @@ class AnnotationPaletteView: UIToolbar {
             textBarButton,
             spaceBetween,
             markdownBarButton,
+            spaceBetween,
+            handwritingBarButton,
             flexibleSpace,
             editOrViewBarButton,
             spaceBetween,
@@ -73,9 +80,14 @@ class AnnotationPaletteView: UIToolbar {
             self?.markdownButton.isSelected = markdownIsSelected
         }).store(in: &cancellables)
 
+        viewModel.$handwritingIsSelected.sink(receiveValue: { [weak self] handwritingIsSelected in
+            self?.handwritingButton.isSelected = handwritingIsSelected
+        }).store(in: &cancellables)
+
         viewModel.$isEditing.sink(receiveValue: { [weak self] isEditing in
             self?.textButton.isHidden = !isEditing
             self?.markdownButton.isHidden = !isEditing
+            self?.handwritingButton.isHidden = !isEditing
             self?.editOrViewButton.isSelected = isEditing
             self?.minimizeOrMaximizeButton.isHidden = isEditing
         }).store(in: &cancellables)
@@ -88,7 +100,7 @@ class AnnotationPaletteView: UIToolbar {
 
 extension AnnotationPaletteView {
     var annotationTypeButtons: [ToggleableButton] {
-        [textButton, markdownButton]
+        [textButton, markdownButton, handwritingButton]
     }
 
     @objc
@@ -103,6 +115,10 @@ extension AnnotationPaletteView {
 
         if toggleableButton == markdownButton {
             viewModel.didSelectMarkdownButton()
+        }
+
+        if toggleableButton == handwritingButton {
+            viewModel.didSelectHandwritingButton()
         }
     }
 

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPaletteView.swift
@@ -24,7 +24,7 @@ class AnnotationPaletteView: UIToolbar {
         self.markdownButton = AnnotationPaletteView.makeToggleableSystemButton(
             systemName: SystemImageName.mSquare.rawValue, color: .darkGray)
         self.handwritingButton = AnnotationPaletteView.makeToggleableSystemButton(
-            systemName: SystemImageName.pencil.rawValue, color: .darkGray)
+            systemName: SystemImageName.scribble.rawValue, color: .darkGray)
         self.editOrViewButton = ImageToggleableButton(
             selectedImage: UIImage(systemName: SystemImageName.eye.rawValue),
             unselectedImage: UIImage(systemName: SystemImageName.pencil.rawValue))

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPartView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationPartView.swift
@@ -2,3 +2,10 @@ import UIKit
 
 protocol AnnotationPartView where Self: UIView {
 }
+
+extension AnnotationPartView {
+    func addAnnotationPartBorders() {
+        self.layer.borderWidth = 0.3
+        self.layer.borderColor = UIColor.lightGray.cgColor
+    }
+}

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationTextView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationTextView.swift
@@ -37,6 +37,8 @@ class AnnotationTextView: UITextView, AnnotationPartView {
             if isSelected {
                 self?.becomeFirstResponder()
                 self?.showSelected()
+            } else {
+                self?.resignFirstResponder()
             }
         }).store(in: &cancellables)
     }

--- a/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationTextView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/Annotation/AnnotationTextView.swift
@@ -19,8 +19,7 @@ class AnnotationTextView: UITextView, AnnotationPartView {
         self.delegate = self
         setUpSubscribers()
         addGestureRecognizers()
-        self.layer.borderWidth = 0.3
-        self.layer.borderColor = UIColor.lightGray.cgColor
+        self.addAnnotationPartBorders()
     }
 
     private func setUpSubscribers() {

--- a/Annotato/Annotato/Views/Main/Auth/AuthViewController.swift
+++ b/Annotato/Annotato/Views/Main/Auth/AuthViewController.swift
@@ -41,6 +41,9 @@ class AuthViewController: UIViewController, Navigable {
             string: "Display Name",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.darkGray]
         )
+
+        // TODO: Remove
+        auth.logIn(email: "hy@gmail.com", password: "123123")
     }
 
     @IBAction private func onSubmitButtonTapped(_ sender: UIButton) {

--- a/Annotato/Annotato/Views/Main/Auth/AuthViewController.swift
+++ b/Annotato/Annotato/Views/Main/Auth/AuthViewController.swift
@@ -41,9 +41,6 @@ class AuthViewController: UIViewController, Navigable {
             string: "Display Name",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.darkGray]
         )
-
-        // TODO: Remove
-        auth.logIn(email: "hy@gmail.com", password: "123123")
     }
 
     @IBAction private func onSubmitButtonTapped(_ sender: UIButton) {

--- a/AnnotatoBackend/Sources/App/Migrations/CreateAnnotationHandwritings.swift
+++ b/AnnotatoBackend/Sources/App/Migrations/CreateAnnotationHandwritings.swift
@@ -1,0 +1,22 @@
+import Foundation
+import FluentKit
+
+struct CreateAnnotationHandwritings: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema(AnnotationHandwritingEntity.schema)
+            .id()
+            .field("handwriting", .data, .required)
+            .field("height", .double, .required)
+            .field("order", .int, .required)
+            .field("annotation_id", .uuid, .required, .references(AnnotationEntity.schema, "id", onDelete: .cascade))
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+            .field("deleted_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema(AnnotationHandwritingEntity.schema)
+            .delete()
+    }
+}

--- a/AnnotatoBackend/Sources/App/Models/AnnotationEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/AnnotationEntity.swift
@@ -26,6 +26,9 @@ final class AnnotationEntity: Model {
     @Children(for: \.$annotationEntity)
     var annotationTextEntities: [AnnotationTextEntity]
 
+    @Children(for: \.$annotationEntity)
+    var annotationHandwritingEntities: [AnnotationHandwritingEntity]
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 

--- a/AnnotatoBackend/Sources/App/Models/AnnotationHandwritingEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/AnnotationHandwritingEntity.swift
@@ -1,0 +1,59 @@
+import Foundation
+import FluentKit
+import AnnotatoSharedLibrary
+
+final class AnnotationHandwritingEntity: Model {
+    static let schema = "annotation_handwritings"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "handwriting")
+    var handwriting: Data
+
+    @Field(key: "height")
+    var height: Double
+
+    @Field(key: "order")
+    var order: Int
+
+    @Parent(key: "annotation_id")
+    var annotationEntity: AnnotationEntity
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    @Timestamp(key: "deleted_at", on: .delete)
+    var deletedAt: Date?
+
+    init() { }
+
+    init(
+        handwriting: Data,
+        height: Double,
+        order: Int,
+        annotationId: AnnotationEntity.IDValue,
+        id: UUID? = nil
+    ) {
+        self.id = id
+        self.handwriting = handwriting
+        self.height = height
+        self.order = order
+        self.$annotationEntity.id = annotationId
+    }
+}
+
+extension AnnotationHandwritingEntity: PersistedEntity {
+    static func fromModel(_ model: AnnotationHandwriting) -> Self {
+        Self(
+            handwriting: model.handwriting,
+            height: model.height,
+            order: model.order,
+            annotationId: model.annotationId,
+            id: model.id
+        )
+    }
+}

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
@@ -43,7 +43,8 @@ extension AnnotationEntity {
 
         let annotationHandwritings = annotation.parts.compactMap({ $0 as? AnnotationHandwriting })
         for annotationHandwriting in annotationHandwritings {
-            if let annotationHandwritingEntity = try await AnnotationHandwritingEntity.find(annotationHandwriting.id, on: tx).get() {
+            if let annotationHandwritingEntity = try await AnnotationHandwritingEntity.find(annotationHandwriting.id,
+                                                                                            on: tx).get() {
                 try await annotationHandwritingEntity.customUpdate(on: tx, usingUpdatedModel: annotationHandwriting)
             } else {
                 let annotationHandwritingEntity = AnnotationHandwritingEntity.fromModel(annotationHandwriting)

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
@@ -10,10 +10,15 @@ extension AnnotationEntity {
         try await self.create(on: tx).get()
 
         let annotationTexts = annotation.parts.compactMap({ $0 as? AnnotationText })
-
         for annotationText in annotationTexts {
-            let annotationEntity = AnnotationTextEntity.fromModel(annotationText)
-            try await annotationEntity.customCreate(on: tx)
+            let annotationTextEntity = AnnotationTextEntity.fromModel(annotationText)
+            try await annotationTextEntity.customCreate(on: tx)
+        }
+
+        let annotationHandwritings = annotation.parts.compactMap({ $0 as? AnnotationHandwriting })
+        for annotationHandwriting in annotationHandwritings {
+            let annotationHandwritingEntity = AnnotationHandwritingEntity.fromModel(annotationHandwriting)
+            try await annotationHandwritingEntity.customCreate(on: tx)
         }
     }
 
@@ -31,8 +36,8 @@ extension AnnotationEntity {
             if let annotationTextEntity = try await AnnotationTextEntity.find(annotationText.id, on: tx).get() {
                 try await annotationTextEntity.customUpdate(on: tx, usingUpdatedModel: annotationText)
             } else {
-                let annotationEntity = AnnotationTextEntity.fromModel(annotationText)
-                try await annotationEntity.customCreate(on: tx)
+                let annotationTextEntity = AnnotationTextEntity.fromModel(annotationText)
+                try await annotationTextEntity.customCreate(on: tx)
             }
         }
 
@@ -41,8 +46,8 @@ extension AnnotationEntity {
             if let annotationHandwritingEntity = try await AnnotationHandwritingEntity.find(annotationHandwriting.id, on: tx).get() {
                 try await annotationHandwritingEntity.customUpdate(on: tx, usingUpdatedModel: annotationHandwriting)
             } else {
-                let annotationEntity = AnnotationHandwritingEntity.fromModel(annotationHandwriting)
-                try await annotationEntity.customCreate(on: tx)
+                let annotationHandwritingEntity = AnnotationHandwritingEntity.fromModel(annotationHandwriting)
+                try await annotationHandwritingEntity.customCreate(on: tx)
             }
         }
 
@@ -56,6 +61,10 @@ extension AnnotationEntity {
 
         for textEntity in annotationTextEntities {
             try await textEntity.customDelete(on: tx)
+        }
+
+        for handwritingEntity in annotationHandwritingEntities {
+            try await handwritingEntity.customDelete(on: tx)
         }
 
         try await self.delete(on: tx).get()
@@ -78,14 +87,12 @@ extension AnnotationEntity {
 
     private func pruneOldAssociations(on tx: Database, usingUpdatedModel annotation: Annotation) async throws {
         let annotationTexts = annotation.parts.compactMap({ $0 as? AnnotationText })
-
         for annotationTextEntity in annotationTextEntities
         where !annotationTexts.contains(where: { $0.id == annotationTextEntity.id }) {
             try await annotationTextEntity.customDelete(on: tx)
         }
 
         let annotationHandwritings = annotation.parts.compactMap { $0 as? AnnotationHandwriting }
-
         for annotationHandwritingEntity in annotationHandwritingEntities
         where !annotationHandwritings.contains(where: { $0.id == annotationHandwritingEntity.id }) {
             try await annotationHandwritingEntity.customDelete(on: tx)

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
@@ -1,0 +1,34 @@
+import FluentKit
+import AnnotatoSharedLibrary
+
+extension AnnotationHandwritingEntity {
+    /// Creates the AnnotationHandwritingEntity instance.
+    /// - Parameter tx: The database instance in a transaction.
+    func customCreate(on tx: Database) async throws {
+        try await self.create(on: tx).get()
+    }
+
+    /// Updates the AnnotationHandwritingEntity instance.
+    /// - Parameters:
+    ///   - tx: The database instance in a transaction.
+    ///   - annotationHandwriting: The updated AnnotationHandwriting instance.
+    func customUpdate(on tx: Database, usingUpdatedModel annotationHandwriting: AnnotationHandwriting) async throws {
+        self.copyPropertiesOf(otherEntity: AnnotationHandwritingEntity.fromModel(annotationHandwriting))
+        try await self.update(on: tx).get()
+    }
+
+    /// Deletes the AnnotationHandwritingEntity instance.
+    /// - Parameter tx: The database instance in a transaction.
+    func customDelete(on tx: Database) async throws {
+        try await self.delete(on: tx).get()
+    }
+
+    func copyPropertiesOf(otherEntity: AnnotationHandwritingEntity) {
+        precondition(id == otherEntity.id)
+
+        handwriting = otherEntity.handwriting
+        height = otherEntity.height
+        order = otherEntity.order
+        $annotationEntity.id = otherEntity.$annotationEntity.id
+    }
+}

--- a/AnnotatoBackend/Sources/App/Persistence/SharedLibraryModels+Persistable/Annotation+Persistable.swift
+++ b/AnnotatoBackend/Sources/App/Persistence/SharedLibraryModels+Persistable/Annotation+Persistable.swift
@@ -4,7 +4,8 @@ import AnnotatoSharedLibrary
 extension Annotation: Persistable {
     static func fromManagedEntity(_ managedEntity: AnnotationEntity) -> Self {
         let textParts = managedEntity.annotationTextEntities.map(AnnotationText.fromManagedEntity)
-        let parts: [AnnotationPart] = textParts
+        let handwritingParts = managedEntity.annotationHandwritingEntities.map(AnnotationHandwriting.fromManagedEntity)
+        let parts: [AnnotationPart] = textParts + handwritingParts
 
         return Self(
             origin: CGPoint(x: managedEntity.originX, y: managedEntity.originY),

--- a/AnnotatoBackend/Sources/App/Persistence/SharedLibraryModels+Persistable/AnnotationHandwriting+Persistable.swift
+++ b/AnnotatoBackend/Sources/App/Persistence/SharedLibraryModels+Persistable/AnnotationHandwriting+Persistable.swift
@@ -1,0 +1,14 @@
+import Foundation
+import AnnotatoSharedLibrary
+
+extension AnnotationHandwriting: Persistable {
+    static func fromManagedEntity(_ managedEntity: AnnotationHandwritingEntity) -> Self {
+        Self(
+            order: managedEntity.order,
+            height: managedEntity.height,
+            annotationId: managedEntity.$annotationEntity.id,
+            handwriting: managedEntity.handwriting,
+            id: managedEntity.id
+        )
+    }
+}

--- a/AnnotatoBackend/Sources/App/configure.swift
+++ b/AnnotatoBackend/Sources/App/configure.swift
@@ -34,6 +34,7 @@ private func addAndRunMigrations(app: Application) throws {
     app.migrations.add(CreateAnnotations())
     app.migrations.add(CreateAnnotationText())
     app.migrations.add(CreateDocumentShares())
+    app.migrations.add(CreateAnnotationHandwritings())
 
     try app.autoMigrate().wait()
 }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
@@ -82,26 +82,42 @@ public final class Annotation: Codable, ObservableObject {
     }
 
     private func addInitialPart() {
+        checkRepresentation()
+
         let newPart = makeNewPlainTextPart()
         parts.append(newPart)
+
+        checkRepresentation()
     }
 
     public func addPlainTextPart() {
+        checkRepresentation()
+
         let newPart = makeNewPlainTextPart()
         parts.append(newPart)
         addedTextPart = newPart
+
+        checkRepresentation()
     }
 
     public func addMarkdownPart() {
+        checkRepresentation()
+
         let newPart = makeNewMarkdownPart()
         parts.append(newPart)
         addedMarkdownPart = newPart
+
+        checkRepresentation()
     }
 
     public func addHandwritingPart() {
+        checkRepresentation()
+
         let newPart = makeNewHandwritingPart()
         parts.append(newPart)
         addedHandwritingPart = newPart
+
+        checkRepresentation()
     }
 
     public func appendTextPartIfNecessary() {
@@ -197,9 +213,38 @@ public final class Annotation: Codable, ObservableObject {
             return
         }
 
+        removePart(part: part)
+    }
+
+    public func removePart(part: AnnotationPart) {
+        checkRepresentation()
+
         part.remove()
         parts.removeAll(where: { $0.id == part.id })
         removedPart = part
+
+        maintainOrderOfParts()
+
+        checkRepresentation()
+    }
+
+    private func maintainOrderOfParts() {
+        parts.enumerated().forEach { idx, part in
+            part.order = idx
+        }
+    }
+}
+
+// MARK: Representation Invariants
+extension Annotation {
+    private func checkRepresentation() {
+        assert(checkOrderOfParts())
+    }
+
+    private func checkOrderOfParts() -> Bool {
+        parts.enumerated().allSatisfy { idx, part in
+            part.order == idx
+        }
     }
 }
 

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
@@ -39,6 +39,7 @@ public final class Annotation: Codable, ObservableObject {
         case origin
         case width
         case texts
+        case handwritings
         case ownerId
         case documentId
     }
@@ -54,7 +55,9 @@ public final class Annotation: Codable, ObservableObject {
         // Note: AnnotationPart protocol has to be split into concrete types to decode
         parts = []
         let texts = try container.decode([AnnotationText].self, forKey: .texts)
+        let handwritings = try container.decode([AnnotationHandwriting].self, forKey: .handwritings)
         parts.append(contentsOf: texts)
+        parts.append(contentsOf: handwritings)
         parts.sort(by: { $0.order < $1.order })
     }
 
@@ -69,6 +72,9 @@ public final class Annotation: Codable, ObservableObject {
         // Note: AnnotationPart protocol has to be split into concrete types to encode
         let texts = parts.compactMap({ $0 as? AnnotationText })
         try container.encode(texts, forKey: .texts)
+
+        let handwritings = parts.compactMap({ $0 as? AnnotationHandwriting })
+        try container.encode(handwritings, forKey: .handwritings)
     }
 
     public var hasNoParts: Bool {

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
@@ -92,6 +92,12 @@ public final class Annotation: Codable, ObservableObject {
         addedMarkdownPart = newPart
     }
 
+    public func addHandwritingPart() {
+        let newPart = makeNewHandwritingPart()
+        parts.append(newPart)
+        addedHandwritingPart = newPart
+    }
+
     public func appendTextPartIfNecessary() {
         guard let lastPart = parts.last else {
             return
@@ -106,9 +112,7 @@ public final class Annotation: Codable, ObservableObject {
             }
         }
 
-        let newPart = makeNewPlainTextPart()
-        parts.append(newPart)
-        addedTextPart = newPart
+        addPlainTextPart()
     }
 
     public func appendMarkdownPartIfNecessary() {
@@ -125,9 +129,7 @@ public final class Annotation: Codable, ObservableObject {
             }
         }
 
-        let newPart = makeNewMarkdownPart()
-        parts.append(newPart)
-        addedMarkdownPart = newPart
+        addMarkdownPart()
     }
 
     public func appendHandwritingPartIfNecessary() {
@@ -141,9 +143,7 @@ public final class Annotation: Codable, ObservableObject {
             return
         }
 
-        let newPart = makeNewHandwritingPart()
-        parts.append(newPart)
-        addedHandwritingPart = newPart
+        addHandwritingPart()
     }
 
     public func setOrigin(to newOrigin: CGPoint) {

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
@@ -199,7 +199,7 @@ public final class Annotation: Codable, ObservableObject {
 
 extension Annotation {
     public var partHeights: Double {
-        parts.reduce(0, {acc, part in
+        parts.reduce(0, { acc, part in
             acc + part.height
         })
     }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
@@ -11,6 +11,7 @@ public final class Annotation: Codable, ObservableObject {
     @Published public private(set) var origin: CGPoint
     @Published public private(set) var addedTextPart: AnnotationText?
     @Published public private(set) var addedMarkdownPart: AnnotationText?
+    @Published public private(set) var addedHandwritingPart: AnnotationHandwriting?
     @Published public private(set) var removedPart: AnnotationPart?
 
     public required init(
@@ -129,6 +130,22 @@ public final class Annotation: Codable, ObservableObject {
         addedMarkdownPart = newPart
     }
 
+    public func appendHandwritingPartIfNecessary() {
+        guard let lastPart = parts.last else {
+            return
+        }
+
+        removePartIfPossible(part: lastPart)
+
+        guard !(lastPart is AnnotationHandwriting) else {
+            return
+        }
+
+        let newPart = makeNewHandwritingPart()
+        parts.append(newPart)
+        addedHandwritingPart = newPart
+    }
+
     public func setOrigin(to newOrigin: CGPoint) {
         self.origin = newOrigin
     }
@@ -150,6 +167,16 @@ public final class Annotation: Codable, ObservableObject {
             height: 30.0,
             order: parts.count,
             annotationId: id,
+            id: UUID()
+        )
+    }
+
+    private func makeNewHandwritingPart() -> AnnotationHandwriting {
+        AnnotationHandwriting(
+            order: parts.count,
+            height: 150.0,
+            annotationId: id,
+            handwriting: Data(),
             id: UUID()
         )
     }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationHandwriting.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationHandwriting.swift
@@ -10,7 +10,7 @@ public final class AnnotationHandwriting: Codable, AnnotationPart {
     public private(set) var handwriting: Data
 
     public var isEmpty: Bool {
-        (try? PKDrawing(data: handwriting).strokes.isEmpty) ?? false
+        (try? PKDrawing(data: handwriting).bounds.isEmpty) ?? false
     }
 
     @Published public private(set) var isRemoved = false

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationHandwriting.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationHandwriting.swift
@@ -1,0 +1,49 @@
+import Foundation
+import PencilKit
+
+public final class AnnotationHandwriting: Codable, AnnotationPart {
+    public var id: UUID
+    public var order: Int
+    public var height: Double
+    public var annotationId: UUID
+
+    public private(set) var handwriting: Data
+
+    public var isEmpty: Bool {
+        (try? PKDrawing(data: handwriting).strokes.isEmpty) ?? false
+    }
+
+    @Published public private(set) var isRemoved = false
+
+    public required init(
+        order: Int,
+        height: Double,
+        annotationId: UUID,
+        handwriting: Data,
+        id: UUID? = nil
+    ) {
+        self.id = id ?? UUID()
+        self.order = order
+        self.height = height
+        self.annotationId = annotationId
+        self.handwriting = handwriting
+    }
+
+    // Define manually as we do not want all properties to be encoded/decoded
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case order
+        case height
+        case annotationId
+        case handwriting
+    }
+
+    public func setHandwriting(to newHandwriting: Data) {
+        self.handwriting = newHandwriting
+    }
+
+    public func remove() {
+        isRemoved = true
+    }
+
+}

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationPart.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationPart.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol AnnotationPart: AnyObject, Codable {
     var id: UUID { get }
-    var order: Int { get }
+    var order: Int { get set }
     var height: Double { get set }
     var annotationId: UUID { get }
     var isEmpty: Bool { get }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationText.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationText.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public final class AnnotationText: Codable, AnnotationPart {
     public let id: UUID
-    public private(set) var order: Int
+    public var order: Int
     public var height: Double
     public let annotationId: UUID
 


### PR DESCRIPTION
Closes #81
Closes #78 

Changes
- Add handwriting annotations
- Make AnnotationPartViewModel "abstract class" instead of protocol to reduce code duplication

Current known issues
- Adding a handwriting to an annotation that already contains a handwriting part does not work
  - The original handwriting part is padded with more height, but that height cannot be drawn on.