### PR TITLE
Complete sharing

### DIFF
--- a/Annotato/Annotato/API/BaseAPI.swift
+++ b/Annotato/Annotato/API/BaseAPI.swift
@@ -2,5 +2,5 @@ struct BaseAPI {
     private static let localApiEndpoint = "http://127.0.0.1:8080"
     private static let remoteApiEndpoint = "http://178.128.111.22:80"
 
-    static let baseAPIUrl = remoteApiEndpoint
+    static let baseAPIUrl = localApiEndpoint
 }

--- a/Annotato/Annotato/API/BaseAPI.swift
+++ b/Annotato/Annotato/API/BaseAPI.swift
@@ -2,5 +2,5 @@ struct BaseAPI {
     private static let localApiEndpoint = "http://127.0.0.1:8080"
     private static let remoteApiEndpoint = "http://178.128.111.22:80"
 
-    static let baseAPIUrl = localApiEndpoint
+    static let baseAPIUrl = remoteApiEndpoint
 }

--- a/Annotato/Annotato/API/DocumentSharesAPI.swift
+++ b/Annotato/Annotato/API/DocumentSharesAPI.swift
@@ -1,0 +1,40 @@
+import AnnotatoSharedLibrary
+import Foundation
+
+struct DocumentSharesAPI {
+    private static let documentSharesUrl = "\(BaseAPI.baseAPIUrl)/documentShares"
+
+    private var httpService: AnnotatoHTTPService
+
+    init() {
+        httpService = URLSessionHTTPService()
+    }
+
+    // MARK: CREATE
+    func createDocumentShare(documentShare: DocumentShare) async -> DocumentShare? {
+        guard let requestData = encodeDocumentShare(documentShare) else {
+            AnnotatoLogger.error("DocumentShare was not created",
+                                 context: "DocumentSharesAPI::createDocumentShare")
+            return nil
+        }
+
+        do {
+            let responseData = try await httpService.post(url: DocumentSharesAPI.documentSharesUrl, data: requestData)
+            return try JSONDecoder().decode(DocumentShare.self, from: responseData)
+        } catch {
+            AnnotatoLogger.error("When creating document share: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func encodeDocumentShare(_ documentShare: DocumentShare) -> Data? {
+        do {
+            let data = try JSONEncoder().encode(documentShare)
+            return data
+        } catch {
+            AnnotatoLogger.error("Could not encode DocumentShare into JSON. \(error.localizedDescription)",
+                                 context: "DocumentSharesAPI::encodeDocumentShare")
+            return nil
+        }
+    }
+}

--- a/Annotato/Annotato/API/DocumentsAPI.swift
+++ b/Annotato/Annotato/API/DocumentsAPI.swift
@@ -3,6 +3,7 @@ import AnnotatoSharedLibrary
 
 struct DocumentsAPI {
     private static let documentsUrl = "\(BaseAPI.baseAPIUrl)/documents"
+    private static let sharedDocumentsUrl = "\(documentsUrl)/shared"
 
     private var httpService: AnnotatoHTTPService
 
@@ -10,10 +11,22 @@ struct DocumentsAPI {
         httpService = URLSessionHTTPService()
     }
 
-    // MARK: LIST
-    func getDocuments(userId: String) async -> [Document]? {
+    // MARK: LIST OWN
+    func getOwnDocuments(userId: String) async -> [Document]? {
         do {
             let responseData = try await httpService.get(url: DocumentsAPI.documentsUrl,
+                                                         params: ["userId": userId])
+            return try JSONDecoder().decode([Document].self, from: responseData)
+        } catch {
+            AnnotatoLogger.error("When fetching documents: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: LIST SHARED
+    func getSharedDocuments(userId: String) async -> [Document]? {
+        do {
+            let responseData = try await httpService.get(url: DocumentsAPI.sharedDocumentsUrl,
                                                          params: ["userId": userId])
             return try JSONDecoder().decode([Document].self, from: responseData)
         } catch {

--- a/Annotato/Annotato/API/DocumentsAPI.swift
+++ b/Annotato/Annotato/API/DocumentsAPI.swift
@@ -18,7 +18,7 @@ struct DocumentsAPI {
                                                          params: ["userId": userId])
             return try JSONDecoder().decode([Document].self, from: responseData)
         } catch {
-            AnnotatoLogger.error("When fetching documents: \(error.localizedDescription)")
+            AnnotatoLogger.error("When fetching own documents: \(error.localizedDescription)")
             return nil
         }
     }
@@ -30,7 +30,7 @@ struct DocumentsAPI {
                                                          params: ["userId": userId])
             return try JSONDecoder().decode([Document].self, from: responseData)
         } catch {
-            AnnotatoLogger.error("When fetching documents: \(error.localizedDescription)")
+            AnnotatoLogger.error("When fetching shared documents: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Annotato/Annotato/Controllers/DocumentController.swift
+++ b/Annotato/Annotato/Controllers/DocumentController.swift
@@ -1,13 +1,30 @@
 import Foundation
 
 struct DocumentController {
-    static func loadAllDocuments(userId: String) async -> [DocumentListViewModel] {
-        let documents = await DocumentsAPI().getDocuments(userId: userId)
+    static func loadOwnDocuments(userId: String) async -> [DocumentListViewModel] {
+        let documents = await DocumentsAPI().getOwnDocuments(userId: userId)
         guard let documents = documents else {
             return []
         }
 
-        return documents.map { DocumentListViewModel(document: $0) }
+        return documents.map { DocumentListViewModel(document: $0, isShared: false) }
+    }
+
+    static func loadSharedDocuments(userId: String) async -> [DocumentListViewModel] {
+        let documents = await DocumentsAPI().getSharedDocuments(userId: userId)
+        guard let documents = documents else {
+            return []
+        }
+
+        return documents.map { DocumentListViewModel(document: $0, isShared: true) }
+    }
+
+    static func loadAllDocuments(userId: String) async -> [DocumentListViewModel] {
+        let ownDocuments = await loadOwnDocuments(userId: userId)
+        let sharedDocuments = await loadSharedDocuments(userId: userId)
+        let allDocuments = ownDocuments + sharedDocuments
+        let sortedDocuments = allDocuments.sorted(by: { $0.name < $1.name })
+        return sortedDocuments
     }
 
     static func loadDocument(documentId: UUID) async -> DocumentViewModel? {

--- a/Annotato/Annotato/Controllers/DocumentShareController.swift
+++ b/Annotato/Annotato/Controllers/DocumentShareController.swift
@@ -1,0 +1,14 @@
+import Foundation
+import AnnotatoSharedLibrary
+
+struct DocumentShareController {
+    static func createDocumentShare(documentId: UUID) async -> DocumentShare? {
+        guard let currentUser = AnnotatoAuth().currentUser else {
+            return nil
+        }
+
+        let documentShare = DocumentShare(documentId: documentId, recipientId: currentUser.uid)
+
+        return await DocumentSharesAPI().createDocumentShare(documentShare: documentShare)
+    }
+}

--- a/Annotato/Annotato/Enums/ImageName.swift
+++ b/Annotato/Annotato/Enums/ImageName.swift
@@ -7,6 +7,7 @@ enum ImageName: String {
 enum SystemImageName: String {
     case eye
     case mSquare = "m.square"
+    case people = "person.2.fill"
     case pencil
     case share = "arrowshape.turn.up.forward"
     case textformat

--- a/Annotato/Annotato/Utils/Sample/SampleData.swift
+++ b/Annotato/Annotato/Utils/Sample/SampleData.swift
@@ -3,15 +3,6 @@ import Foundation
 import AnnotatoSharedLibrary
 
 class SampleData {
-    static var exampleDocumentsInList: [DocumentListViewModel] =
-        [
-            DocumentListViewModel(id: UUID(), name: "Lab01 Qns"),
-            DocumentListViewModel(id: UUID(), name: "L0 Overview"),
-            DocumentListViewModel(id: UUID(), name: "L1 Intro"),
-            DocumentListViewModel(id: UUID(), name: "Firebase Clean Code"),
-            DocumentListViewModel(id: UUID(), name: "Test E")
-        ]
-
     static var exampleDocument: Document {
         Document(name: "Clean Code", ownerId: "owner123", baseFileUrl: firebasePdfUrlString, id: UUID())
     }

--- a/Annotato/Annotato/ViewModels/Document/DocumentListViewModel.swift
+++ b/Annotato/Annotato/ViewModels/Document/DocumentListViewModel.swift
@@ -2,15 +2,19 @@ import Foundation
 import AnnotatoSharedLibrary
 
 class DocumentListViewModel {
-    let id: UUID
-    private(set) var name: String
+    let document: Document
+    let isShared: Bool
 
-    init(id: UUID, name: String) {
-        self.id = id
-        self.name = name
+    var id: UUID {
+        document.id
     }
 
-    convenience init(document: Document) {
-        self.init(id: document.id, name: document.name)
+    var name: String {
+        document.name
+    }
+
+    init(document: Document, isShared: Bool) {
+        self.document = document
+        self.isShared = isShared
     }
 }

--- a/Annotato/Annotato/Views/Components/Protocols/AlertPresentable.swift
+++ b/Annotato/Annotato/Views/Components/Protocols/AlertPresentable.swift
@@ -3,7 +3,7 @@ import UIKit
 protocol AlertPresentable where Self: UIViewController {
     func presentTimedAlert(title: String, message: String)
     func presentErrorAlert(errorMessage: String)
-    func presentSuccessAlert(successMessage: String)
+    func presentSuccessAlert(successMessage: String, completion: (() -> Void)?)
     func presentWarningAlert(warningMessage: String, confirmHandler: @escaping () -> Void)
 }
 
@@ -29,7 +29,7 @@ extension AlertPresentable {
         present(alertController, animated: true)
     }
 
-    func presentSuccessAlert(successMessage: String) {
+    func presentSuccessAlert(successMessage: String, completion: (() -> Void)? = nil) {
         let alertController = UIAlertController(
             title: "",
             message: successMessage,
@@ -37,7 +37,7 @@ extension AlertPresentable {
 
         let displayDuration = DispatchTime.now() + 1
         DispatchQueue.main.asyncAfter(deadline: displayDuration) {
-            alertController.dismiss(animated: true, completion: nil)
+            alertController.dismiss(animated: true, completion: completion)
         }
 
         present(alertController, animated: true)

--- a/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
+++ b/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
@@ -69,4 +69,9 @@ extension Navigable {
     func goBack() {
         self.dismiss(animated: true, completion: nil)
     }
+
+    func goBackWithRefresh() {
+        goBack()
+        presentingViewController?.viewWillAppear(true)
+    }
 }

--- a/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
+++ b/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
@@ -38,6 +38,16 @@ extension Navigable {
         present(viewController, animated: true, completion: nil)
     }
 
+    func goToImportByCode() {
+        guard let viewController = DocumentCodeImportViewController.instantiatePartialScreenFromStoryboard(
+            .document
+        ) else {
+            return
+        }
+
+        present(viewController, animated: true, completion: nil)
+    }
+
     func goToImportingFiles() {
         let documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.pdf], asCopy: true)
         documentPicker.delegate = self as? UIDocumentPickerDelegate

--- a/Annotato/Annotato/Views/Document/List/DocumentCodeImportViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentCodeImportViewController.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+class DocumentCodeImportViewController: UIViewController, AlertPresentable {
+    @IBOutlet private var documentCodeField: UITextField!
+
+    @IBAction private func didTapImportButton(_ sender: UIButton) {
+        importDocument()
+    }
+
+    private func importDocument() {
+        let code = documentCodeField.text ?? ""
+
+        if code.isEmptyOrWhitespaceOnly {
+            presentErrorAlert(errorMessage: "Please enter a code")
+        }
+    }
+}

--- a/Annotato/Annotato/Views/Document/List/DocumentCodeImportViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentCodeImportViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class DocumentCodeImportViewController: UIViewController, AlertPresentable {
+class DocumentCodeImportViewController: UIViewController, AlertPresentable, Navigable {
     @IBOutlet private var documentCodeField: UITextField!
 
     @IBAction private func didTapImportButton(_ sender: UIButton) {
@@ -10,8 +10,24 @@ class DocumentCodeImportViewController: UIViewController, AlertPresentable {
     private func importDocument() {
         let code = documentCodeField.text ?? ""
 
-        if code.isEmptyOrWhitespaceOnly {
+        guard !code.isEmptyOrWhitespaceOnly else {
             presentErrorAlert(errorMessage: "Please enter a code")
+            return
+        }
+
+        guard let documentId = UUID(uuidString: code) else {
+            presentErrorAlert(errorMessage: "Please enter a valid code")
+            return
+        }
+
+        Task {
+            let documentShare = await DocumentShareController.createDocumentShare(documentId: documentId)
+            if documentShare != nil {
+                presentSuccessAlert(successMessage: "Successfully imported document!", completion: goBack)
+            } else {
+                presentErrorAlert(
+                    errorMessage: "The document was not imported. It may already exist in your collection")
+            }
         }
     }
 }

--- a/Annotato/Annotato/Views/Document/List/DocumentCodeImportViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentCodeImportViewController.swift
@@ -23,7 +23,10 @@ class DocumentCodeImportViewController: UIViewController, AlertPresentable, Navi
         Task {
             let documentShare = await DocumentShareController.createDocumentShare(documentId: documentId)
             if documentShare != nil {
-                presentSuccessAlert(successMessage: "Successfully imported document!", completion: goBack)
+                presentSuccessAlert(
+                    successMessage: "Successfully imported document!",
+                    completion: goBackWithRefresh
+                )
             } else {
                 presentErrorAlert(
                     errorMessage: "The document was not imported. It may already exist in your collection")

--- a/Annotato/Annotato/Views/Document/List/DocumentListCollectionCellView.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListCollectionCellView.swift
@@ -3,7 +3,7 @@ import UIKit
 class DocumentListCollectionCellView: UICollectionViewCell {
     var document: DocumentListViewModel?
     let nameLabelHeight = 30.0
-    let shareIconWidth = 20.0
+    let shareIconWidth = 25.0
     weak var actionDelegate: DocumentListCollectionCellViewDelegate?
 
     @available(*, unavailable)

--- a/Annotato/Annotato/Views/Document/List/DocumentListCollectionCellView.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListCollectionCellView.swift
@@ -3,6 +3,7 @@ import UIKit
 class DocumentListCollectionCellView: UICollectionViewCell {
     var document: DocumentListViewModel?
     let nameLabelHeight = 30.0
+    let shareIconWidth = 20.0
     weak var actionDelegate: DocumentListCollectionCellViewDelegate?
 
     @available(*, unavailable)
@@ -17,6 +18,9 @@ class DocumentListCollectionCellView: UICollectionViewCell {
     func initializeSubviews() {
         addTapGestureRecognizer()
         initializeIconImageView()
+        if document?.isShared ?? false {
+            initializeShareIconImageView()
+        }
         initializeNameLabel()
     }
 
@@ -33,6 +37,19 @@ class DocumentListCollectionCellView: UICollectionViewCell {
         imageView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
     }
 
+    private func initializeShareIconImageView() {
+        let image = UIImage(systemName: SystemImageName.people.rawValue) ?? UIImage()
+        let imageView = UIImageView(image: image)
+        imageView.tintColor = .systemGray
+
+        addSubview(imageView)
+
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.widthAnchor.constraint(equalToConstant: shareIconWidth).isActive = true
+        imageView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
+        imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -5.0).isActive = true
+    }
+
     private func initializeNameLabel() {
         guard let document = document else {
             return
@@ -45,10 +62,11 @@ class DocumentListCollectionCellView: UICollectionViewCell {
         addSubview(label)
 
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.widthAnchor.constraint(equalToConstant: self.frame.width).isActive = true
+        let width = document.isShared ? self.frame.width - shareIconWidth : self.frame.width
+        label.widthAnchor.constraint(equalToConstant: width).isActive = true
         label.heightAnchor.constraint(equalToConstant: nameLabelHeight).isActive = true
         label.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-        label.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        label.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
     }
 
     private func addTapGestureRecognizer() {

--- a/Annotato/Annotato/Views/Document/List/DocumentListImportMenu.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListImportMenu.swift
@@ -1,0 +1,73 @@
+import UIKit
+
+class DocumentListImportMenu: UIStackView {
+    weak var actionDelegate: DocumentListImportMenuDelegate?
+    private let buttonHeight = 30.0
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.axis = .vertical
+
+        self.backgroundColor = UIColor.systemGray6
+        self.layer.cornerRadius = 15.0
+        self.distribution = .fillProportionally
+
+        initializeSubviews()
+    }
+
+    private func initializeSubviews() {
+        let fromIpadButton = makeFromIpadButton()
+        let divider = makeDivider()
+        let fromCodeButton = makeFromCodeButton()
+
+        self.addArrangedSubview(fromIpadButton)
+        self.addArrangedSubview(divider)
+        self.addArrangedSubview(fromCodeButton)
+
+        divider.heightAnchor.constraint(equalToConstant: 0.5).isActive = true
+    }
+
+    private func makeImportMenuButton() -> UIButton {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.configuration = .plain()
+        return button
+    }
+
+    private func makeFromIpadButton() -> UIButton {
+        let button = makeImportMenuButton()
+        button.setTitle("From iPad", for: .normal)
+        button.addTarget(self, action: #selector(didTapFromIpadButton), for: .touchUpInside)
+        return button
+    }
+
+    private func makeFromCodeButton() -> UIButton {
+        let button = makeImportMenuButton()
+        button.setTitle("From code", for: .normal)
+        button.addTarget(self, action: #selector(didTapFromCodeButton), for: .touchUpInside)
+        return button
+    }
+
+    private func makeDivider() -> UIView {
+        let divider = UIView()
+        divider.backgroundColor = UIColor.systemGray
+        return divider
+    }
+
+    @objc
+    private func didTapFromIpadButton() {
+        actionDelegate?.didTapFromIpadButton()
+        self.isHidden = true
+    }
+
+    @objc
+    private func didTapFromCodeButton() {
+        actionDelegate?.didTapFromCodeButton()
+        self.isHidden = true
+    }
+}

--- a/Annotato/Annotato/Views/Document/List/DocumentListImportMenuDelegate.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListImportMenuDelegate.swift
@@ -1,0 +1,4 @@
+protocol DocumentListImportMenuDelegate: AnyObject {
+    func didTapFromIpadButton()
+    func didTapFromCodeButton()
+}

--- a/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
@@ -136,6 +136,6 @@ extension DocumentListViewController: DocumentListImportMenuDelegate {
     }
 
     func didTapFromCodeButton() {
-        print("tapped from code button")
+        goToImportByCode()
     }
 }

--- a/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
@@ -57,10 +57,10 @@ class DocumentListViewController: UIViewController, AlertPresentable, SpinnerPre
     private func initializeDocumentsCollectionView() {
         Task {
             guard let userId = AnnotatoAuth().currentUser?.uid else {
-                AnnotatoLogger.info("Could not get current user. Sample documents will be used.",
+                AnnotatoLogger.info("Could not get current user.",
                                     context: "DocumentListViewController::initializeSubviews")
 
-                documents = SampleData.exampleDocumentsInList
+                documents = []
                 addDocumentsSubview()
                 return
             }

--- a/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
@@ -7,8 +7,8 @@ class DocumentListViewController: UIViewController, AlertPresentable, SpinnerPre
     private var documents: [DocumentListViewModel]?
     let toolbarHeight = 50.0
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
 
         initializeDocumentsCollectionView()
     }

--- a/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
@@ -2,6 +2,8 @@ import UIKit
 
 class DocumentListViewController: UIViewController, AlertPresentable, SpinnerPresentable {
     let spinner = UIActivityIndicatorView(style: .large)
+    private var toolbar = DocumentListToolbarView()
+    private var importMenu = DocumentListImportMenu()
     private var documents: [DocumentListViewModel]?
     let toolbarHeight = 50.0
 
@@ -16,10 +18,12 @@ class DocumentListViewController: UIViewController, AlertPresentable, SpinnerPre
 
         initializeSpinner()
         initializeToolbar()
+        initializeImportMenu()
+        view.bringSubviewToFront(importMenu)
     }
 
     private func initializeToolbar() {
-        let toolbar = DocumentListToolbarView(
+        toolbar = DocumentListToolbarView(
             frame: CGRect(x: .zero, y: .zero, width: frame.width, height: toolbarHeight)
         )
         toolbar.actionDelegate = self
@@ -31,6 +35,23 @@ class DocumentListViewController: UIViewController, AlertPresentable, SpinnerPre
         toolbar.heightAnchor.constraint(equalToConstant: toolbarHeight).isActive = true
         toolbar.topAnchor.constraint(equalTo: margins.topAnchor).isActive = true
         toolbar.centerXAnchor.constraint(equalTo: margins.centerXAnchor).isActive = true
+    }
+
+    private func initializeImportMenu() {
+        let width = 120.0
+        let height = 80.0
+        importMenu = DocumentListImportMenu(frame: .zero)
+
+        view.addSubview(importMenu)
+
+        importMenu.translatesAutoresizingMaskIntoConstraints = false
+        importMenu.topAnchor.constraint(equalTo: toolbar.bottomAnchor).isActive = true
+        importMenu.rightAnchor.constraint(equalTo: margins.rightAnchor).isActive = true
+        importMenu.widthAnchor.constraint(equalToConstant: width).isActive = true
+        importMenu.heightAnchor.constraint(equalToConstant: height).isActive = true
+
+        importMenu.isHidden = true
+        importMenu.actionDelegate = self
     }
 
     private func initializeDocumentsCollectionView() {
@@ -80,7 +101,11 @@ extension DocumentListViewController: DocumentListToolbarDelegate,
         Navigable {
 
     func didTapImportFileButton() {
-        goToImportingFiles()
+        importMenu.isHidden.toggle()
+
+        if !importMenu.isHidden {
+            view.bringSubviewToFront(importMenu)
+        }
     }
 
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt baseFileUrls: [URL]) {
@@ -102,5 +127,15 @@ extension DocumentListViewController: DocumentListToolbarDelegate,
 
     func didSelectCellView(document: DocumentListViewModel) {
         goToDocumentEdit(documentId: document.id)
+    }
+}
+
+extension DocumentListViewController: DocumentListImportMenuDelegate {
+    func didTapFromIpadButton() {
+        goToImportingFiles()
+    }
+
+    func didTapFromCodeButton() {
+        print("tapped from code button")
     }
 }

--- a/Annotato/Annotato/Views/Document/Storyboards/Document.storyboard
+++ b/Annotato/Annotato/Views/Document/Storyboards/Document.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad7_9" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Annotato/Annotato/Views/Document/Storyboards/Document.storyboard
+++ b/Annotato/Annotato/Views/Document/Storyboards/Document.storyboard
@@ -87,7 +87,58 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VZv-Ns-mH5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1346" y="34"/>
+            <point key="canvasLocation" x="1351" y="34"/>
+        </scene>
+        <!--Document Code Import View Controller-->
+        <scene sceneID="9nm-Mh-q6U">
+            <objects>
+                <viewController storyboardIdentifier="DocumentCodeImportViewController" id="3D2-JS-uhA" customClass="DocumentCodeImportViewController" customModule="Annotato" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="eox-9w-SPg">
+                        <rect key="frame" x="0.0" y="0.0" width="744" height="1133"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter the code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VHr-Vu-Jht">
+                                <rect key="frame" x="226.5" y="463.5" width="291" height="96"/>
+                                <fontDescription key="fontDescription" name="SavoyeLetPlain" family="Savoye LET" pointSize="80"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BFr-TH-QV7">
+                                <rect key="frame" x="162" y="608.5" width="420" height="34"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="420" id="wnI-WV-c21"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="20"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hGs-Uf-z7I">
+                                <rect key="frame" x="338.5" y="672.5" width="67" height="31"/>
+                                <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Import"/>
+                                <connections>
+                                    <action selector="didTapImportButton:" destination="3D2-JS-uhA" eventType="touchUpInside" id="36n-Le-UIx"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="daH-BJ-hXm"/>
+                        <color key="backgroundColor" red="0.94509803920000002" green="0.91372549020000005" blue="0.87058823529999996" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="VHr-Vu-Jht" firstAttribute="centerX" secondItem="daH-BJ-hXm" secondAttribute="centerX" id="Djp-x1-hEm"/>
+                            <constraint firstItem="VHr-Vu-Jht" firstAttribute="centerY" secondItem="daH-BJ-hXm" secondAttribute="centerY" multiplier="0.9" id="HQj-2f-dXc"/>
+                            <constraint firstItem="hGs-Uf-z7I" firstAttribute="centerX" secondItem="daH-BJ-hXm" secondAttribute="centerX" id="HaJ-p4-r1D"/>
+                            <constraint firstItem="BFr-TH-QV7" firstAttribute="centerY" secondItem="daH-BJ-hXm" secondAttribute="centerY" multiplier="1.1" id="hcC-F1-ZbF"/>
+                            <constraint firstItem="hGs-Uf-z7I" firstAttribute="top" secondItem="BFr-TH-QV7" secondAttribute="bottom" constant="30" id="jBk-ph-Log"/>
+                            <constraint firstItem="BFr-TH-QV7" firstAttribute="centerX" secondItem="daH-BJ-hXm" secondAttribute="centerX" id="nEc-k6-HE5"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="documentCodeField" destination="BFr-TH-QV7" id="X8s-oC-JFv"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GUh-eD-2xi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1994.3548387096773" y="33.627537511032656"/>
         </scene>
     </scenes>
     <resources>

--- a/Annotato/Annotato/Views/Main/Storyboards/Main.storyboard
+++ b/Annotato/Annotato/Views/Main/Storyboards/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="ipad7_9" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/AnnotatoBackend/Sources/App/Controllers/DocumentsController.swift
+++ b/AnnotatoBackend/Sources/App/Controllers/DocumentsController.swift
@@ -14,7 +14,7 @@ struct DocumentsController {
             throw Abort(.badRequest)
         }
 
-        return try await DocumentsDataAccess.list(db: req.db, userId: userId)
+        return try await DocumentsDataAccess.listAll(db: req.db, userId: userId)
     }
 
     static func listShared(req: Request) async throws -> [Document] {

--- a/AnnotatoBackend/Sources/App/Controllers/DocumentsController.swift
+++ b/AnnotatoBackend/Sources/App/Controllers/DocumentsController.swift
@@ -7,14 +7,14 @@ struct DocumentsController {
         case userId
     }
 
-    static func list(req: Request) async throws -> [Document] {
+    static func listOwn(req: Request) async throws -> [Document] {
         let userId: String? = req.query[QueryParams.userId.rawValue]
 
         guard let userId = userId else {
             throw Abort(.badRequest)
         }
 
-        return try await DocumentsDataAccess.listAll(db: req.db, userId: userId)
+        return try await DocumentsDataAccess.listOwn(db: req.db, userId: userId)
     }
 
     static func listShared(req: Request) async throws -> [Document] {

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentSharesDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentSharesDataAccess.swift
@@ -12,6 +12,12 @@ struct DocumentSharesDataAccess {
             )
         }
 
+        let document = try await DocumentsDataAccess.read(db: db, documentId: documentShare.documentId)
+
+        if document.ownerId == documentShare.recipientId {
+            throw DocumentShareError.sharingWithSelf(documentShare: documentShare, requestType: .create)
+        }
+
         let documentShareEntity = DocumentShareEntity.fromModel(documentShare)
 
         try await db.transaction { tx in

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -16,6 +16,16 @@ struct DocumentsDataAccess {
         return documentEntities.map(Document.fromManagedEntity)
     }
 
+    static func listAll(db: Database, userId: String) async throws -> [Document] {
+        let ownDocuments = try await list(db: db, userId: userId)
+        let sharedDocuments = try await listShared(db: db, userId: userId)
+        let allDocuments = ownDocuments + sharedDocuments
+        let sortedDocuments = allDocuments.sorted(by: {(firstDocument: Document, secondDocument: Document) -> Bool in
+            firstDocument.name < secondDocument.name
+        })
+        return sortedDocuments
+    }
+
     static func listShared(db: Database, userId: String) async throws -> [Document] {
         let documentEntities = try await DocumentEntity.query(on: db)
             .join(DocumentShareEntity.self, on: \DocumentEntity.$id == \DocumentShareEntity.$documentEntity.$id)

--- a/AnnotatoBackend/Sources/App/Models/Error/DocumentShareError.swift
+++ b/AnnotatoBackend/Sources/App/Models/Error/DocumentShareError.swift
@@ -1,0 +1,30 @@
+import Foundation
+import AnnotatoSharedLibrary
+
+struct DocumentShareError: Error {
+    enum ErrorType: String {
+        case sharingWithSelf
+    }
+
+    enum RequestType: String {
+        case create
+        case update
+    }
+
+    let errorType: ErrorType
+    let requestType: RequestType
+    let description: String
+
+    static func sharingWithSelf(
+        documentShare: DocumentShare,
+        requestType: RequestType
+    ) -> DocumentShareError {
+        let modelType = String(describing: DocumentShareEntity.self)
+
+        return DocumentShareError(
+            errorType: .sharingWithSelf, requestType: requestType,
+            description: "Could not \(requestType) \(modelType) - \(modelType) with document ID " +
+            "\(documentShare.documentId) already belongs to recipient with ID \(documentShare.recipientId)"
+        )
+    }
+}

--- a/AnnotatoBackend/Sources/App/Routes/DocumentsRouter.swift
+++ b/AnnotatoBackend/Sources/App/Routes/DocumentsRouter.swift
@@ -1,7 +1,9 @@
 import Vapor
 
 func documentsRouter(documents: RoutesBuilder) {
-    documents.get(use: DocumentsController.list)
+    documents.get(use: DocumentsController.listOwn)
+
+    documents.get("shared", use: DocumentsController.listShared)
 
     documents.post(use: DocumentsController.create)
 


### PR DESCRIPTION
Note: Using local api endpoint for testing. To be reverted before merge.
Closes  #79 

Testing
- Get share code from within the document edit view by clicking the arrow button on the toolbar
- To import:
  - Click import button from document list view: choose `From code` from the menu
  - Enter the code and tap the `Import` button
  - If valid, the document will be imported and appear in the list
 
Expected behaviours
- Cannot share with self
- Cannot import the same document by code more than once
- Error message is general at the moment since it seems like the backend doesn't pass error messages to the frontend? 

Sidenote: `AnnotatoError` isn't extensible as more specific error types cannot extend from it? I created a `DocumentSharesError` for errors specific to it, for example to signal when a user is trying to share with self. Also what is `AnnotatoError` supposed to be for actually? Is it just db errors?