### PR TITLE
Store user credentials locally and implement logout

### DIFF
--- a/Annotato/Annotato/Adapters/AnnotatoAuthService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoAuthService.swift
@@ -6,6 +6,7 @@ protocol AnnotatoAuthService {
     var currentUser: AnnotatoUser? { get }
     func signUp(email: String, password: String, displayName: String)
     func logIn(email: String, password: String)
+    func logOut()
 }
 
 extension AnnotatoAuthService {
@@ -29,5 +30,9 @@ extension AnnotatoAuthService {
         }
 
         return decodedUser
+    }
+
+    func purgeLocalCredentials() {
+        UserDefaults.standard.removeObject(forKey: savedUserKey)
     }
 }

--- a/Annotato/Annotato/Adapters/AnnotatoAuthService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoAuthService.swift
@@ -1,5 +1,4 @@
 import AnnotatoSharedLibrary
-import Foundation
 
 protocol AnnotatoAuthService {
     var delegate: AnnotatoAuthDelegate? { get set }
@@ -7,32 +6,4 @@ protocol AnnotatoAuthService {
     func signUp(email: String, password: String, displayName: String)
     func logIn(email: String, password: String)
     func logOut()
-}
-
-extension AnnotatoAuthService {
-    private var savedUserKey: String {
-        "savedUser"
-    }
-
-    func storeCredentialsLocally() {
-        guard let currentUser = currentUser,
-              let encodedUser = try? JSONEncoder().encode(currentUser) else {
-            return
-        }
-
-        UserDefaults.standard.set(encodedUser, forKey: savedUserKey)
-    }
-
-    func fetchLocalCredentials() -> AnnotatoUser? {
-        guard let savedUser = UserDefaults.standard.object(forKey: savedUserKey) as? Data,
-              let decodedUser = try? JSONDecoder().decode(AnnotatoUser.self, from: savedUser) else {
-            return nil
-        }
-
-        return decodedUser
-    }
-
-    func purgeLocalCredentials() {
-        UserDefaults.standard.removeObject(forKey: savedUserKey)
-    }
 }

--- a/Annotato/Annotato/Adapters/AnnotatoAuthService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoAuthService.swift
@@ -1,8 +1,33 @@
 import AnnotatoSharedLibrary
+import Foundation
 
 protocol AnnotatoAuthService {
     var delegate: AnnotatoAuthDelegate? { get set }
     var currentUser: AnnotatoUser? { get }
     func signUp(email: String, password: String, displayName: String)
     func logIn(email: String, password: String)
+}
+
+extension AnnotatoAuthService {
+    private var savedUserKey: String {
+        "savedUser"
+    }
+
+    func storeCredentialsLocally() {
+        guard let currentUser = currentUser,
+              let encodedUser = try? JSONEncoder().encode(currentUser) else {
+            return
+        }
+
+        UserDefaults.standard.set(encodedUser, forKey: savedUserKey)
+    }
+
+    func fetchLocalCredentials() -> AnnotatoUser? {
+        guard let savedUser = UserDefaults.standard.object(forKey: savedUserKey) as? Data,
+              let decodedUser = try? JSONDecoder().decode(AnnotatoUser.self, from: savedUser) else {
+            return nil
+        }
+
+        return decodedUser
+    }
 }

--- a/Annotato/Annotato/Auth/AnnotatoAuth.swift
+++ b/Annotato/Annotato/Auth/AnnotatoAuth.swift
@@ -1,4 +1,5 @@
 import AnnotatoSharedLibrary
+import Foundation
 
 class AnnotatoAuth {
     private var authService: AnnotatoAuthService
@@ -8,7 +9,7 @@ class AnnotatoAuth {
     }
 
     var currentUser: AnnotatoUser? {
-        authService.currentUser
+        authService.fetchLocalCredentials() ?? authService.currentUser
     }
 
     var delegate: AnnotatoAuthDelegate? {
@@ -22,5 +23,7 @@ class AnnotatoAuth {
 
     func logIn(email: String, password: String) {
         authService.logIn(email: email, password: password)
+
+        authService.storeCredentialsLocally()
     }
 }

--- a/Annotato/Annotato/Auth/AnnotatoAuth.swift
+++ b/Annotato/Annotato/Auth/AnnotatoAuth.swift
@@ -26,4 +26,10 @@ class AnnotatoAuth {
 
         authService.storeCredentialsLocally()
     }
+
+    func logOut() {
+        authService.logOut()
+
+        authService.purgeLocalCredentials()
+    }
 }

--- a/Annotato/Annotato/Auth/AnnotatoAuth.swift
+++ b/Annotato/Annotato/Auth/AnnotatoAuth.swift
@@ -9,7 +9,7 @@ class AnnotatoAuth {
     }
 
     var currentUser: AnnotatoUser? {
-        authService.fetchLocalCredentials() ?? authService.currentUser
+        fetchLocalUserCredentials() ?? authService.currentUser
     }
 
     var delegate: AnnotatoAuthDelegate? {
@@ -24,12 +24,41 @@ class AnnotatoAuth {
     func logIn(email: String, password: String) {
         authService.logIn(email: email, password: password)
 
-        authService.storeCredentialsLocally()
+        storeCredentialsLocally()
     }
 
     func logOut() {
         authService.logOut()
 
-        authService.purgeLocalCredentials()
+        purgeLocalCredentials()
+    }
+}
+
+// MARK: Local storage of user credentials
+extension AnnotatoAuth {
+    private var savedUserKey: String {
+        "savedUser"
+    }
+
+    private func storeCredentialsLocally() {
+        guard let currentUser = currentUser,
+              let encodedUser = try? JSONEncoder().encode(currentUser) else {
+            return
+        }
+
+        UserDefaults.standard.set(encodedUser, forKey: savedUserKey)
+    }
+
+    private func fetchLocalUserCredentials() -> AnnotatoUser? {
+        guard let savedUser = UserDefaults.standard.object(forKey: savedUserKey) as? Data,
+              let decodedUser = try? JSONDecoder().decode(AnnotatoUser.self, from: savedUser) else {
+            return nil
+        }
+
+        return decodedUser
+    }
+
+    private func purgeLocalCredentials() {
+        UserDefaults.standard.removeObject(forKey: savedUserKey)
     }
 }

--- a/Annotato/Annotato/Auth/FirebaseAuth.swift
+++ b/Annotato/Annotato/Auth/FirebaseAuth.swift
@@ -51,6 +51,20 @@ class FirebaseAuth: AnnotatoAuthService {
         }
     }
 
+    func logOut() {
+        guard let currentUser = currentUser else {
+            return
+        }
+
+        do {
+            try Auth.auth().signOut()
+            AnnotatoLogger.info("\(currentUser.email) logged out")
+        } catch {
+            AnnotatoLogger.error("When trying to log out \(currentUser.email). \(error.localizedDescription)",
+                                 context: "FirebaseAuth::logOut")
+        }
+    }
+
     private func setDisplayName(to displayName: String, email: String) {
         let changeRequest = self.currentFirebaseUser?.createProfileChangeRequest()
         changeRequest?.displayName = displayName

--- a/Annotato/Annotato/SceneDelegate.swift
+++ b/Annotato/Annotato/SceneDelegate.swift
@@ -14,10 +14,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new
         // (see `application:configurationForConnectingSceneSession` instead).
 
-        // swiftlint:disable unused_optional_binding
-        guard let _ = (scene as? UIWindowScene) else {
+        guard let windowScene = (scene as? UIWindowScene) else {
             return
         }
+
+        let window = UIWindow(windowScene: windowScene)
+
+        // Skips AuthViewController if user is already logged in
+        window.rootViewController = AnnotatoAuth().currentUser != nil
+            ? DocumentListViewController.instantiateFullScreenFromStoryboard(.document)
+            : AuthViewController.instantiateFullScreenFromStoryboard(.main)
+
+        self.window = window
+        window.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Annotato/Annotato/SceneDelegate.swift
+++ b/Annotato/Annotato/SceneDelegate.swift
@@ -14,19 +14,30 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new
         // (see `application:configurationForConnectingSceneSession` instead).
 
-        guard let windowScene = (scene as? UIWindowScene) else {
+        // swiftlint:disable unused_optional_binding
+        guard let _ = (scene as? UIWindowScene) else {
             return
         }
 
-        let window = UIWindow(windowScene: windowScene)
-
-        // Skips AuthViewController if user is already logged in
-        window.rootViewController = AnnotatoAuth().currentUser != nil
+        window?.rootViewController = AnnotatoAuth().currentUser != nil
             ? DocumentListViewController.instantiateFullScreenFromStoryboard(.document)
             : AuthViewController.instantiateFullScreenFromStoryboard(.main)
+    }
 
-        self.window = window
-        window.makeKeyAndVisible()
+    func changeRootViewController(newRootViewController: UIViewController, animated: Bool = true) {
+        guard let window = self.window else {
+            return
+        }
+
+        window.rootViewController = newRootViewController
+
+        if animated {
+            UIView.transition(with: window,
+                              duration: 0.5,
+                              options: [.transitionCrossDissolve],
+                              animations: nil,
+                              completion: nil)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Annotato/Annotato/Views/Components/Protocols/AlertPresentable.swift
+++ b/Annotato/Annotato/Views/Components/Protocols/AlertPresentable.swift
@@ -4,7 +4,7 @@ protocol AlertPresentable where Self: UIViewController {
     func presentTimedAlert(title: String, message: String)
     func presentErrorAlert(errorMessage: String)
     func presentSuccessAlert(successMessage: String, completion: (() -> Void)?)
-    func presentWarningAlert(warningMessage: String, confirmHandler: @escaping () -> Void)
+    func presentWarningAlert(alertTitle: String, warningMessage: String?, confirmHandler: @escaping () -> Void)
 }
 
 extension AlertPresentable {
@@ -43,9 +43,10 @@ extension AlertPresentable {
         present(alertController, animated: true)
     }
 
-    func presentWarningAlert(warningMessage: String, confirmHandler: @escaping () -> Void) {
+    func presentWarningAlert(alertTitle: String = "Are you sure?", warningMessage: String? = nil,
+                             confirmHandler: @escaping () -> Void) {
         let alertController = UIAlertController(
-            title: "Are you sure?",
+            title: alertTitle,
             message: warningMessage,
             preferredStyle: .alert)
 

--- a/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
+++ b/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
@@ -3,29 +3,38 @@ import UIKit
 import UniformTypeIdentifiers
 
 protocol Navigable where Self: UIViewController {
-    func goToDocumentList()
+    func goToAuth(asNewRootViewController: Bool)
+    func goToDocumentList(asNewRootViewController: Bool)
     func goToDocumentEdit()
     func goToDocumentEdit(documentId: UUID)
     func goToImportingFiles()
 }
 
 extension Navigable {
-    func goToAuth() {
+    func goToAuth(asNewRootViewController: Bool = false) {
         guard let authViewController = AuthViewController.instantiateFromStoryboard(.main) else {
             return
         }
 
-        goToNewRootViewController(authViewController)
+        if asNewRootViewController {
+            goToNewRootViewController(authViewController)
+        } else {
+            present(authViewController, animated: true, completion: nil)
+        }
     }
 
-    func goToDocumentList() {
+    func goToDocumentList(asNewRootViewController: Bool = false) {
         guard let listViewController = DocumentListViewController.instantiateFullScreenFromStoryboard(
             .document
         ) else {
             return
         }
 
-        goToNewRootViewController(listViewController)
+        if asNewRootViewController {
+            goToNewRootViewController(listViewController)
+        } else {
+            present(listViewController, animated: true, completion: nil)
+        }
     }
 
     private func goToNewRootViewController(_ newRootViewController: UIViewController) {

--- a/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
+++ b/Annotato/Annotato/Views/Components/Protocols/Navigable.swift
@@ -10,13 +10,27 @@ protocol Navigable where Self: UIViewController {
 }
 
 extension Navigable {
+    func goToAuth() {
+        guard let authViewController = AuthViewController.instantiateFromStoryboard(.main) else {
+            return
+        }
+
+        goToNewRootViewController(authViewController)
+    }
+
     func goToDocumentList() {
-        guard let viewController = DocumentListViewController.instantiateFullScreenFromStoryboard(
+        guard let listViewController = DocumentListViewController.instantiateFullScreenFromStoryboard(
             .document
         ) else {
             return
         }
-        present(viewController, animated: true, completion: nil)
+
+        goToNewRootViewController(listViewController)
+    }
+
+    private func goToNewRootViewController(_ newRootViewController: UIViewController) {
+        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
+            .changeRootViewController(newRootViewController: newRootViewController, animated: true)
     }
 
     func goToDocumentEdit() {

--- a/Annotato/Annotato/Views/Document/List/DocumentListToolbarDelegate.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListToolbarDelegate.swift
@@ -1,3 +1,4 @@
 protocol DocumentListToolbarDelegate: AnyObject {
+    func didTapLogOutButton()
     func didTapImportFileButton()
 }

--- a/Annotato/Annotato/Views/Document/List/DocumentListToolbarView.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListToolbarView.swift
@@ -11,12 +11,22 @@ class DocumentListToolbarView: UIToolbar {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
+        let logOutButton = makeLogOutButton()
         let importFileButton = makeImportFileButton()
-        self.items = [flexibleSpace, importFileButton]
+        self.items = [logOutButton, flexibleSpace, importFileButton]
+    }
+
+    private func makeLogOutButton() -> UIBarButtonItem {
+        UIBarButtonItem(title: "Log Out", style: .plain, target: self, action: #selector(didTapLogOutButton))
     }
 
     private func makeImportFileButton() -> UIBarButtonItem {
         UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(didTapImportFileButton))
+    }
+
+    @objc
+    private func didTapLogOutButton() {
+        actionDelegate?.didTapLogOutButton()
     }
 
     @objc

--- a/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
@@ -104,7 +104,7 @@ extension DocumentListViewController: DocumentListToolbarDelegate,
         presentWarningAlert(alertTitle: "Log Out",
                             warningMessage: "Are you sure you want to log out?", confirmHandler: { [weak self] in
             AnnotatoAuth().logOut()
-            self?.goToAuth()
+            self?.goToAuth(asNewRootViewController: true)
         })
     }
 

--- a/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
+++ b/Annotato/Annotato/Views/Document/List/DocumentListViewController.swift
@@ -100,6 +100,14 @@ extension DocumentListViewController: DocumentListToolbarDelegate,
         DocumentListCollectionCellViewDelegate,
         Navigable {
 
+    func didTapLogOutButton() {
+        presentWarningAlert(alertTitle: "Log Out",
+                            warningMessage: "Are you sure you want to log out?", confirmHandler: { [weak self] in
+            AnnotatoAuth().logOut()
+            self?.goToAuth()
+        })
+    }
+
     func didTapImportFileButton() {
         importMenu.isHidden.toggle()
 

--- a/Annotato/Annotato/Views/Main/Auth/AuthViewController.swift
+++ b/Annotato/Annotato/Views/Main/Auth/AuthViewController.swift
@@ -95,7 +95,7 @@ extension AuthViewController: AnnotatoAuthDelegate, AlertPresentable {
     }
 
     func logInDidSucceed() {
-        goToDocumentList()
+        goToDocumentList(asNewRootViewController: true)
     }
 
     func signUpDidSucceed() {

--- a/Annotato/Annotato/Views/Main/Storyboards/Main.storyboard
+++ b/Annotato/Annotato/Views/Main/Storyboards/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Auth View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="AuthViewController" customModule="Annotato" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="AuthViewController" id="BYZ-38-t0r" customClass="AuthViewController" customModule="Annotato" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="744" height="1133"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Auth/AnnotatoUser.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Auth/AnnotatoUser.swift
@@ -1,4 +1,4 @@
-public class AnnotatoUser {
+public class AnnotatoUser: Codable {
     public let uid: String
     public let email: String
     public let displayName: String


### PR DESCRIPTION
Closes #97 

Changes
- Once user is logged in, the user details (excluding password) is stored locally. This means that 
   - Users do not need to re-authenticate they close and open the application
   - Users can now use the application offline
- Implement logout functionality
   - Logs out from the authservice and purges the user details that was stored locally

Testing
- Log in, then close and kill the application. When application is launched again, you will be directed to the list view directly
- Log out, then close and kill the application. When application is launched again, you will be directed to the auth view

For the design decision in changing the root view controller, see this - https://fluffy.es/how-to-transition-from-login-screen-to-tab-bar-controller/