### PR TITLE
Offline to online websocket

### DIFF
--- a/Annotato/Annotato/Persistence/RemotePersistenceManager/RemotePersistenceManager.swift
+++ b/Annotato/Annotato/Persistence/RemotePersistenceManager/RemotePersistenceManager.swift
@@ -3,13 +3,13 @@ struct RemotePersistenceManager {
     private static let localApiEndpoint = "http://127.0.0.1:8080"
     private static let remoteApiEndpoint = "http://178.128.111.22:80"
 
-    static let baseAPIUrl = remoteApiEndpoint
+    static let baseAPIUrl = localApiEndpoint
 
     // WebSocket
     private static let localApiWsEndpoint = "ws://127.0.0.1:8080"
     private static let remoteApiWsEndpoint = "ws://178.128.111.22:80"
 
-    static let baseWsAPIUrl = remoteApiWsEndpoint
+    static let baseWsAPIUrl = localApiWsEndpoint
 }
 
 extension RemotePersistenceManager: PersistenceManager {

--- a/Annotato/Annotato/Persistence/RemotePersistenceManager/RemotePersistenceManager.swift
+++ b/Annotato/Annotato/Persistence/RemotePersistenceManager/RemotePersistenceManager.swift
@@ -3,13 +3,13 @@ struct RemotePersistenceManager {
     private static let localApiEndpoint = "http://127.0.0.1:8080"
     private static let remoteApiEndpoint = "http://178.128.111.22:80"
 
-    static let baseAPIUrl = localApiEndpoint
+    static let baseAPIUrl = remoteApiEndpoint
 
     // WebSocket
     private static let localApiWsEndpoint = "ws://127.0.0.1:8080"
     private static let remoteApiWsEndpoint = "ws://178.128.111.22:80"
 
-    static let baseWsAPIUrl = localApiWsEndpoint
+    static let baseWsAPIUrl = remoteApiWsEndpoint
 }
 
 extension RemotePersistenceManager: PersistenceManager {

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -28,7 +28,7 @@ struct AnnotationDataAccess {
     }
 
     static func update(db: Database, annotationId: UUID, annotation: Annotation) async throws -> Annotation {
-        guard let annotationEntity = try await AnnotationEntity.findIncludingDeleted(annotationId, on: db).get() else {
+        guard let annotationEntity = try await AnnotationEntity.findWithDeleted(annotationId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .update,
                                               modelType: String(describing: Annotation.self),
                                               modelId: annotationId)
@@ -45,7 +45,7 @@ struct AnnotationDataAccess {
     }
 
     static func delete(db: Database, annotationId: UUID) async throws -> Annotation {
-        guard let annotationEntity = try await AnnotationEntity.findIncludingDeleted(annotationId, on: db).get() else {
+        guard let annotationEntity = try await AnnotationEntity.findWithDeleted(annotationId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .delete,
                                               modelType: String(describing: Annotation.self),
                                               modelId: annotationId)
@@ -58,7 +58,7 @@ struct AnnotationDataAccess {
         return Annotation.fromManagedEntity(annotationEntity)
     }
 
-    static func canFindIncludingDeleted(db: Database, annotationId: UUID) async -> Bool {
-        (try? await AnnotationEntity.findIncludingDeleted(annotationId, on: db).get()) != nil
+    static func canFindWithDeleted(db: Database, annotationId: UUID) async -> Bool {
+        (try? await AnnotationEntity.findWithDeleted(annotationId, on: db).get()) != nil
     }
 }

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -3,6 +3,21 @@ import Fluent
 import AnnotatoSharedLibrary
 
 struct AnnotationDataAccess {
+    static func listWithDeleted(db: Database, annotationIds: [UUID]) async throws -> [Annotation] {
+        let annotationEntities = try await AnnotationEntity
+            .query(on: db)
+            .filter(\.$id ~~ annotationIds)
+            .withDeleted()
+            .all()
+            .get()
+
+        for annotationEntity in annotationEntities {
+            try await annotationEntity.loadAssociationsWithDeleted(on: db)
+        }
+
+        return annotationEntities.map(Annotation.fromManagedEntity)
+    }
+
     static func create(db: Database, annotation: Annotation) async throws -> Annotation {
         let annotationEntity = AnnotationEntity.fromModel(annotation)
 

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -28,7 +28,7 @@ struct AnnotationDataAccess {
     }
 
     static func update(db: Database, annotationId: UUID, annotation: Annotation) async throws -> Annotation {
-        guard let annotationEntity = try await AnnotationEntity.find(annotationId, on: db).get() else {
+        guard let annotationEntity = try await AnnotationEntity.findIncludingDeleted(annotationId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .update,
                                               modelType: String(describing: Annotation.self),
                                               modelId: annotationId)
@@ -56,5 +56,9 @@ struct AnnotationDataAccess {
         }
 
         return Annotation.fromManagedEntity(annotationEntity)
+    }
+
+    static func canFindIncludingDeleted(db: Database, annotationId: UUID) async -> Bool {
+        (try? await AnnotationEntity.findIncludingDeleted(annotationId, on: db).get()) != nil
     }
 }

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -87,19 +87,19 @@ struct AnnotationDataAccess {
             try await annotationEntity.customCreate(on: tx, usingModel: annotation)
         }
 
-        try await annotationEntity.loadAssociations(on: db)
+        try await annotationEntity.loadAssociationsWithDeleted(on: db)
 
         return Annotation.fromManagedEntity(annotationEntity)
     }
 
     static func read(db: Database, annotationId: UUID) async throws -> Annotation {
-        guard let annotationEntity = try await AnnotationEntity.find(annotationId, on: db).get() else {
+        guard let annotationEntity = try await AnnotationEntity.findWithDeleted(annotationId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .read,
                                               modelType: String(describing: Annotation.self),
                                               modelId: annotationId)
         }
 
-        try await annotationEntity.loadAssociations(on: db)
+        try await annotationEntity.loadAssociationsWithDeleted(on: db)
 
         return Annotation.fromManagedEntity(annotationEntity)
     }
@@ -116,7 +116,7 @@ struct AnnotationDataAccess {
         }
 
         // Load again as there might be new entities created
-        try await annotationEntity.loadAssociations(on: db)
+        try await annotationEntity.loadAssociationsWithDeleted(on: db)
 
         return Annotation.fromManagedEntity(annotationEntity)
     }

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -3,13 +3,12 @@ import Fluent
 import AnnotatoSharedLibrary
 
 struct AnnotationDataAccess {
-    static func listWithDeleted(db: Database, annotationIds: [UUID]) async throws -> [Annotation] {
+    static func listEntitiesCreatedAfterDateWithDeleted(db: Database, date: Date) async throws -> [Annotation] {
         let annotationEntities = try await AnnotationEntity
             .query(on: db)
-            .filter(\.$id ~~ annotationIds)
+            .filter(\.$createdAt > date)
             .withDeleted()
-            .all()
-            .get()
+            .all().get()
 
         for annotationEntity in annotationEntities {
             try await annotationEntity.loadAssociationsWithDeleted(on: db)

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -45,7 +45,7 @@ struct AnnotationDataAccess {
     }
 
     static func delete(db: Database, annotationId: UUID) async throws -> Annotation {
-        guard let annotationEntity = try await AnnotationEntity.find(annotationId, on: db).get() else {
+        guard let annotationEntity = try await AnnotationEntity.findIncludingDeleted(annotationId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .delete,
                                               modelType: String(describing: Annotation.self),
                                               modelId: annotationId)

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -4,6 +4,20 @@ import AnnotatoSharedLibrary
 import Foundation
 
 struct AnnotationDataAccess {
+    static func listWithDeleted(db: Database, annotationIds: [UUID]) async throws -> [Annotation] {
+        let annotationEntities = try await AnnotationEntity
+            .query(on: db)
+            .filter(\.$id ~~ annotationIds)
+            .withDeleted()
+            .all().get()
+
+        for annotationEntity in annotationEntities {
+            try await annotationEntity.loadAssociationsWithDeleted(on: db)
+        }
+
+        return annotationEntities.map(Annotation.fromManagedEntity)
+    }
+
     static func listEntitiesCreatedAfterDateWithDeleted(
         db: Database,
         date: Date,

--- a/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/AnnotationDataAccess.swift
@@ -18,6 +18,20 @@ struct AnnotationDataAccess {
         return annotationEntities.map(Annotation.fromManagedEntity)
     }
 
+    static func listEntitiesUpdatedAfterDateWithDeleted(db: Database, date: Date) async throws -> [Annotation] {
+        let annotationEntities = try await AnnotationEntity
+            .query(on: db)
+            .filter(\.$updatedAt > date)
+            .withDeleted()
+            .all().get()
+
+        for annotationEntity in annotationEntities {
+            try await annotationEntity.loadAssociationsWithDeleted(on: db)
+        }
+
+        return annotationEntities.map(Annotation.fromManagedEntity)
+    }
+
     static func create(db: Database, annotation: Annotation) async throws -> Annotation {
         let annotationEntity = AnnotationEntity.fromModel(annotation)
 

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentSharesDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentSharesDataAccess.swift
@@ -32,13 +32,12 @@ struct DocumentSharesDataAccess {
         db: Database,
         documentShare: DocumentShare
     ) async throws -> DocumentShare? {
-        // swiftlint:disable:next first_where
         guard let documentShareEntity = try await DocumentShareEntity
             .query(on: db)
             .filter(\.$documentEntity.$id == documentShare.documentId)
             .filter(\.$recipientId == documentShare.recipientId)
-            .first()
-            .get()
+            .withDeleted()
+            .first().get()
         else {
             return nil
         }
@@ -50,6 +49,7 @@ struct DocumentSharesDataAccess {
         let documentShareEntities = try await DocumentShareEntity
             .query(on: db)
             .filter(\.$documentEntity.$id == documentId)
+            .withDeleted()
             .all().get()
 
         return documentShareEntities.map(DocumentShare.fromManagedEntity)

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -31,13 +31,12 @@ struct DocumentsDataAccess {
         return documentEntities.map(Document.fromManagedEntity)
     }
 
-    static func listWithDeleted(db: Database, documentIds: [UUID]) async throws -> [Document] {
+    static func listEntitiesUpdatedAfterDateWithDeleted(db: Database, date: Date) async throws -> [Document] {
         let documentEntities = try await DocumentEntity
             .query(on: db)
-            .filter(\.$id ~~ documentIds)
+            .filter(\.$updatedAt > date)
             .withDeleted()
-            .all()
-            .get()
+            .all().get()
 
         for documentEntity in documentEntities {
             try await documentEntity.loadAssociationsWithDeleted(on: db)

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -7,11 +7,12 @@ struct DocumentsDataAccess {
     static func listOwn(db: Database, userId: String) async throws -> [Document] {
         let documentEntities = try await DocumentEntity.query(on: db)
             .filter(\.$ownerId == userId)
+            .withDeleted()
             .sort(\.$name)
             .all().get()
 
         for documentEntity in documentEntities {
-            try await documentEntity.loadAssociations(on: db)
+            try await documentEntity.loadAssociationsWithDeleted(on: db)
         }
 
         return documentEntities.map(Document.fromManagedEntity)
@@ -21,11 +22,12 @@ struct DocumentsDataAccess {
         let documentEntities = try await DocumentEntity.query(on: db)
             .join(DocumentShareEntity.self, on: \DocumentEntity.$id == \DocumentShareEntity.$documentEntity.$id)
             .filter(DocumentShareEntity.self, \DocumentShareEntity.$recipientId == userId)
+            .withDeleted()
             .sort(\.$name)
             .all().get()
 
         for documentEntity in documentEntities {
-            try await documentEntity.loadAssociations(on: db)
+            try await documentEntity.loadAssociationsWithDeleted(on: db)
         }
 
         return documentEntities.map(Document.fromManagedEntity)
@@ -110,19 +112,19 @@ struct DocumentsDataAccess {
             try await documentEntity.customCreate(on: tx, usingModel: document)
         }
 
-        try await documentEntity.loadAssociations(on: db)
+        try await documentEntity.loadAssociationsWithDeleted(on: db)
 
         return Document.fromManagedEntity(documentEntity)
     }
 
     static func read(db: Database, documentId: UUID) async throws -> Document {
-        guard let documentEntity = try await DocumentEntity.find(documentId, on: db).get() else {
+        guard let documentEntity = try await DocumentEntity.findWithDeleted(documentId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .read,
                                               modelType: String(describing: Document.self),
                                               modelId: documentId)
         }
 
-        try await documentEntity.loadAssociations(on: db)
+        try await documentEntity.loadAssociationsWithDeleted(on: db)
 
         return Document.fromManagedEntity(documentEntity)
     }
@@ -145,7 +147,7 @@ struct DocumentsDataAccess {
     }
 
     static func delete(db: Database, documentId: UUID) async throws -> Document {
-        guard let documentEntity = try await DocumentEntity.find(documentId, on: db).get() else {
+        guard let documentEntity = try await DocumentEntity.findWithDeleted(documentId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .delete,
                                               modelType: String(describing: Document.self),
                                               modelId: documentId)

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -56,7 +56,7 @@ struct DocumentsDataAccess {
     }
 
     static func update(db: Database, documentId: UUID, document: Document) async throws -> Document {
-        guard let documentEntity = try await DocumentEntity.findIncludingDeleted(documentId, on: db).get() else {
+        guard let documentEntity = try await DocumentEntity.findWithDeleted(documentId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .update,
                                               modelType: String(describing: Document.self),
                                               modelId: documentId)
@@ -86,7 +86,7 @@ struct DocumentsDataAccess {
         return Document.fromManagedEntity(documentEntity)
     }
 
-    static func canFindIncludingDeleted(db: Database, documentId: UUID) async -> Bool {
-        (try? await DocumentEntity.findIncludingDeleted(documentId, on: db).get()) != nil
+    static func canFindWithDeleted(db: Database, documentId: UUID) async -> Bool {
+        (try? await DocumentEntity.findWithDeleted(documentId, on: db).get()) != nil
     }
 }

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -31,6 +31,20 @@ struct DocumentsDataAccess {
         return documentEntities.map(Document.fromManagedEntity)
     }
 
+    static func listEntitiesCreatedAfterDateWithDeleted(db: Database, date: Date) async throws -> [Document] {
+        let documentEntities = try await DocumentEntity
+            .query(on: db)
+            .filter(\.$createdAt > date)
+            .withDeleted()
+            .all().get()
+
+        for documentEntity in documentEntities {
+            try await documentEntity.loadAssociationsWithDeleted(on: db)
+        }
+
+        return documentEntities.map(Document.fromManagedEntity)
+    }
+
     static func listEntitiesUpdatedAfterDateWithDeleted(db: Database, date: Date) async throws -> [Document] {
         let documentEntities = try await DocumentEntity
             .query(on: db)

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -31,26 +31,27 @@ struct DocumentsDataAccess {
         return documentEntities.map(Document.fromManagedEntity)
     }
 
-    static func listEntitiesCreatedAfterDateWithDeleted(db: Database, date: Date) async throws -> [Document] {
-        let documentEntities = try await DocumentEntity
+    static func listEntitiesUpdatedAfterDateWithDeleted(
+        db: Database,
+        date: Date,
+        userId: String
+    ) async throws -> [Document] {
+        let ownDocumentEntities = try await DocumentEntity
             .query(on: db)
-            .filter(\.$createdAt > date)
-            .withDeleted()
-            .all().get()
-
-        for documentEntity in documentEntities {
-            try await documentEntity.loadAssociationsWithDeleted(on: db)
-        }
-
-        return documentEntities.map(Document.fromManagedEntity)
-    }
-
-    static func listEntitiesUpdatedAfterDateWithDeleted(db: Database, date: Date) async throws -> [Document] {
-        let documentEntities = try await DocumentEntity
-            .query(on: db)
+            .filter(\.$ownerId == userId)
             .filter(\.$updatedAt > date)
             .withDeleted()
             .all().get()
+
+        let sharedDocumentEntities = try await DocumentEntity
+            .query(on: db)
+            .join(DocumentShareEntity.self, on: \DocumentEntity.$id == \DocumentShareEntity.$documentEntity.$id)
+            .filter(DocumentShareEntity.self, \DocumentShareEntity.$recipientId == userId)
+            .filter(\.$updatedAt > date)
+            .withDeleted()
+            .all().get()
+
+        let documentEntities = ownDocumentEntities + sharedDocumentEntities
 
         for documentEntity in documentEntities {
             try await documentEntity.loadAssociationsWithDeleted(on: db)

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -1,6 +1,7 @@
 import Vapor
 import Fluent
 import AnnotatoSharedLibrary
+import Foundation
 
 struct DocumentsDataAccess {
     static func listOwn(db: Database, userId: String) async throws -> [Document] {
@@ -83,5 +84,9 @@ struct DocumentsDataAccess {
         }
 
         return Document.fromManagedEntity(documentEntity)
+    }
+
+    static func isFoundIncludingDeleted(db: Database, documentId: UUID) async -> Bool {
+        (try? await DocumentEntity.findIncludingDeleted(documentId, on: db).get() != nil) != nil
     }
 }

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -139,7 +139,7 @@ struct DocumentsDataAccess {
         }
 
         // Load again as there might be new entities created
-        try await documentEntity.loadAssociations(on: db)
+        try await documentEntity.loadAssociationsWithDeleted(on: db)
 
         return Document.fromManagedEntity(documentEntity)
     }

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -31,6 +31,21 @@ struct DocumentsDataAccess {
         return documentEntities.map(Document.fromManagedEntity)
     }
 
+    static func listWithDeleted(db: Database, documentIds: [UUID]) async throws -> [Document] {
+        let documentEntities = try await DocumentEntity
+            .query(on: db)
+            .filter(\.$id ~~ documentIds)
+            .withDeleted()
+            .all()
+            .get()
+
+        for documentEntity in documentEntities {
+            try await documentEntity.loadAssociationsWithDeleted(on: db)
+        }
+
+        return documentEntities.map(Document.fromManagedEntity)
+    }
+
     static func create(db: Database, document: Document) async throws -> Document {
         let documentEntity = DocumentEntity.fromModel(document)
 

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -56,7 +56,7 @@ struct DocumentsDataAccess {
     }
 
     static func update(db: Database, documentId: UUID, document: Document) async throws -> Document {
-        guard let documentEntity = try await DocumentEntity.find(documentId, on: db).get() else {
+        guard let documentEntity = try await DocumentEntity.findIncludingDeleted(documentId, on: db).get() else {
             throw AnnotatoError.modelNotFound(requestType: .update,
                                               modelType: String(describing: Document.self),
                                               modelId: documentId)
@@ -86,7 +86,7 @@ struct DocumentsDataAccess {
         return Document.fromManagedEntity(documentEntity)
     }
 
-    static func isFoundIncludingDeleted(db: Database, documentId: UUID) async -> Bool {
-        (try? await DocumentEntity.findIncludingDeleted(documentId, on: db).get() != nil) != nil
+    static func canFindIncludingDeleted(db: Database, documentId: UUID) async -> Bool {
+        (try? await DocumentEntity.findIncludingDeleted(documentId, on: db).get()) != nil
     }
 }

--- a/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
+++ b/AnnotatoBackend/Sources/App/DataAccess/DocumentsDataAccess.swift
@@ -31,6 +31,20 @@ struct DocumentsDataAccess {
         return documentEntities.map(Document.fromManagedEntity)
     }
 
+    static func listWithDeleted(db: Database, documentIds: [UUID]) async throws -> [Document] {
+        let documentEntities = try await DocumentEntity
+            .query(on: db)
+            .filter(\.$id ~~ documentIds)
+            .withDeleted()
+            .all().get()
+
+        for documentEntity in documentEntities {
+            try await documentEntity.loadAssociationsWithDeleted(on: db)
+        }
+
+        return documentEntities.map(Document.fromManagedEntity)
+    }
+
     static func listEntitiesUpdatedAfterDateWithDeleted(
         db: Database,
         date: Date,

--- a/AnnotatoBackend/Sources/App/Extensions/Array+AppendIfNotNil.swift
+++ b/AnnotatoBackend/Sources/App/Extensions/Array+AppendIfNotNil.swift
@@ -1,0 +1,7 @@
+extension Array {
+    mutating func appendIfNotNil(_ newElement: Element?) {
+        if let element = newElement {
+            self.append(element)
+        }
+    }
+}

--- a/AnnotatoBackend/Sources/App/Extensions/ChildrenProperty+WithDeleted.swift
+++ b/AnnotatoBackend/Sources/App/Extensions/ChildrenProperty+WithDeleted.swift
@@ -1,0 +1,9 @@
+import FluentKit
+
+extension ChildrenProperty {
+    func loadWithDeleted(on database: Database) -> EventLoopFuture<Void> {
+        self.query(on: database).withDeleted().all().map {
+            self.value = $0
+        }
+    }
+}

--- a/AnnotatoBackend/Sources/App/Extensions/Model+IncludingDeleted.swift
+++ b/AnnotatoBackend/Sources/App/Extensions/Model+IncludingDeleted.swift
@@ -1,0 +1,16 @@
+import FluentKit
+
+extension Model {
+    public static func findIncludingDeleted(
+        _ id: Self.IDValue?,
+        on database: Database
+    ) -> EventLoopFuture<Self?> {
+        guard let id = id else {
+            return database.eventLoop.makeSucceededFuture(nil)
+        }
+        return Self.query(on: database)
+            .filter(\._$id == id)
+            .withDeleted()
+            .first()
+    }
+}

--- a/AnnotatoBackend/Sources/App/Extensions/Model+WithDeleted.swift
+++ b/AnnotatoBackend/Sources/App/Extensions/Model+WithDeleted.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 extension Model {
-    public static func findIncludingDeleted(
+    public static func findWithDeleted(
         _ id: Self.IDValue?,
         on database: Database
     ) -> EventLoopFuture<Self?> {

--- a/AnnotatoBackend/Sources/App/Extensions/OptionalChildProperty+WithDeleted.swift
+++ b/AnnotatoBackend/Sources/App/Extensions/OptionalChildProperty+WithDeleted.swift
@@ -1,0 +1,9 @@
+import FluentKit
+
+extension OptionalChildProperty {
+    func loadWithDeleted(on database: Database) -> EventLoopFuture<Void> {
+        self.query(on: database).withDeleted().first().map {
+            self.value = $0
+        }
+    }
+}

--- a/AnnotatoBackend/Sources/App/Models/AnnotationEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/AnnotationEntity.swift
@@ -41,6 +41,10 @@ final class AnnotationEntity: Model {
     @Timestamp(key: "deleted_at", on: .delete)
     var deletedAt: Date?
 
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     init() { }
 
     init(

--- a/AnnotatoBackend/Sources/App/Models/AnnotationHandwritingEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/AnnotationHandwritingEntity.swift
@@ -29,6 +29,10 @@ final class AnnotationHandwritingEntity: Model {
     @Timestamp(key: "deleted_at", on: .delete)
     var deletedAt: Date?
 
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     init() { }
 
     init(

--- a/AnnotatoBackend/Sources/App/Models/AnnotationTextEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/AnnotationTextEntity.swift
@@ -32,6 +32,10 @@ final class AnnotationTextEntity: Model {
     @Timestamp(key: "deleted_at", on: .delete)
     var deletedAt: Date?
 
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     init() { }
 
     init(

--- a/AnnotatoBackend/Sources/App/Models/DocumentEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/DocumentEntity.swift
@@ -29,6 +29,10 @@ final class DocumentEntity: Model {
     @Timestamp(key: "deleted_at", on: .delete)
     var deletedAt: Date?
 
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     init() { }
 
     init(

--- a/AnnotatoBackend/Sources/App/Models/DocumentShareEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/DocumentShareEntity.swift
@@ -23,6 +23,10 @@ final class DocumentShareEntity: Model {
     @Timestamp(key: "deleted_at", on: .delete)
     var deletedAt: Date?
 
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     init() { }
 
     init(

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
@@ -43,7 +43,7 @@ extension AnnotationEntity {
         let annotationTexts = annotation.parts.compactMap({ $0 as? AnnotationText })
         for annotationText in annotationTexts {
             if let annotationTextEntity = try await AnnotationTextEntity
-                .findIncludingDeleted(annotationText.id, on: tx).get() {
+                .findWithDeleted(annotationText.id, on: tx).get() {
                 try await annotationTextEntity.customUpdate(on: tx, usingUpdatedModel: annotationText)
             } else {
                 let annotationTextEntity = AnnotationTextEntity.fromModel(annotationText)
@@ -54,7 +54,7 @@ extension AnnotationEntity {
         let annotationHandwritings = annotation.parts.compactMap({ $0 as? AnnotationHandwriting })
         for annotationHandwriting in annotationHandwritings {
             if let annotationHandwritingEntity = try await AnnotationHandwritingEntity
-                .findIncludingDeleted(annotationHandwriting.id, on: tx).get() {
+                .findWithDeleted(annotationHandwriting.id, on: tx).get() {
                 try await annotationHandwritingEntity.customUpdate(on: tx, usingUpdatedModel: annotationHandwriting)
             } else {
                 let annotationHandwritingEntity = AnnotationHandwritingEntity.fromModel(annotationHandwriting)
@@ -63,7 +63,7 @@ extension AnnotationEntity {
         }
 
         let selectionBox = annotation.selectionBox
-        if let selectionBoxEntity = try await SelectionBoxEntity.findIncludingDeleted(selectionBox.id, on: tx).get() {
+        if let selectionBoxEntity = try await SelectionBoxEntity.findWithDeleted(selectionBox.id, on: tx).get() {
             try await selectionBoxEntity.customUpdate(on: tx, usingUpdatedModel: selectionBox)
         } else {
             let selectionBoxEntity = SelectionBoxEntity.fromModel(selectionBox)

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
@@ -31,6 +31,11 @@ extension AnnotationEntity {
     ///   - tx: The database instance in a transaction.
     ///   - annotation: The updated Annotation instance.
     func customUpdate(on tx: Database, usingUpdatedModel annotation: Annotation) async throws {
+        if annotation.isDeleted && !self.isDeleted {
+            try await self.customDelete(on: tx)
+            return
+        }
+
         if annotation.isDeleted {
             return
         }

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationEntity+CRUD.swift
@@ -76,7 +76,8 @@ extension AnnotationEntity {
     /// Deletes the AnnotationEntity instance. Use this function to cascade deletes.
     /// - Parameter tx: The database instance in a transaction.
     func customDelete(on tx: Database) async throws {
-        try await self.loadAssociations(on: tx)
+        try await self.restore(on: tx)
+        try await self.loadAssociationsWithDeleted(on: tx)
 
         for textEntity in annotationTextEntities {
             try await textEntity.customDelete(on: tx)
@@ -95,6 +96,12 @@ extension AnnotationEntity {
         try await self.$annotationTextEntities.load(on: db).get()
         try await self.$selectionBox.load(on: db).get()
         try await self.$annotationHandwritingEntities.load(on: db).get()
+    }
+
+    func loadAssociationsWithDeleted(on db: Database) async throws {
+        try await self.$annotationTextEntities.loadWithDeleted(on: db).get()
+        try await self.$selectionBox.loadWithDeleted(on: db).get()
+        try await self.$annotationHandwritingEntities.loadWithDeleted(on: db).get()
     }
 
     func copyPropertiesOf(otherEntity: AnnotationEntity) {

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
@@ -25,6 +25,7 @@ extension AnnotationHandwritingEntity {
     /// Deletes the AnnotationHandwritingEntity instance.
     /// - Parameter tx: The database instance in a transaction.
     func customDelete(on tx: Database) async throws {
+        try await self.restore(on: tx)
         try await self.delete(on: tx).get()
     }
 

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
@@ -13,6 +13,11 @@ extension AnnotationHandwritingEntity {
     ///   - tx: The database instance in a transaction.
     ///   - annotationHandwriting: The updated AnnotationHandwriting instance.
     func customUpdate(on tx: Database, usingUpdatedModel annotationHandwriting: AnnotationHandwriting) async throws {
+        if annotationHandwriting.isDeleted {
+            return
+        }
+
+        try await self.restore(on: tx)
         self.copyPropertiesOf(otherEntity: AnnotationHandwritingEntity.fromModel(annotationHandwriting))
         try await self.update(on: tx).get()
     }

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationHandwritingEntity+CRUD.swift
@@ -13,6 +13,11 @@ extension AnnotationHandwritingEntity {
     ///   - tx: The database instance in a transaction.
     ///   - annotationHandwriting: The updated AnnotationHandwriting instance.
     func customUpdate(on tx: Database, usingUpdatedModel annotationHandwriting: AnnotationHandwriting) async throws {
+        if annotationHandwriting.isDeleted && !self.isDeleted {
+            try await self.customDelete(on: tx)
+            return
+        }
+
         if annotationHandwriting.isDeleted {
             return
         }

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationTextEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationTextEntity+CRUD.swift
@@ -25,6 +25,7 @@ extension AnnotationTextEntity {
     /// Deletes the AnnotationTextEntity instance.
     /// - Parameter tx: The database instance in a transaction.
     func customDelete(on tx: Database) async throws {
+        try await self.restore(on: tx)
         try await self.delete(on: tx).get()
     }
 

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationTextEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationTextEntity+CRUD.swift
@@ -13,6 +13,11 @@ extension AnnotationTextEntity {
     ///   - tx: The database instance in a transaction.
     ///   - annotationText: The updated AnnotationText instance.
     func customUpdate(on tx: Database, usingUpdatedModel annotationText: AnnotationText) async throws {
+        if annotationText.isDeleted {
+            return
+        }
+
+        try await self.restore(on: tx)
         self.copyPropertiesOf(otherEntity: AnnotationTextEntity.fromModel(annotationText))
         try await self.update(on: tx).get()
     }

--- a/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationTextEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/AnnotationTextEntity+CRUD.swift
@@ -13,10 +13,14 @@ extension AnnotationTextEntity {
     ///   - tx: The database instance in a transaction.
     ///   - annotationText: The updated AnnotationText instance.
     func customUpdate(on tx: Database, usingUpdatedModel annotationText: AnnotationText) async throws {
-        if annotationText.isDeleted {
+        if annotationText.isDeleted && !self.isDeleted {
+            try await self.customDelete(on: tx)
             return
         }
 
+        if annotationText.isDeleted {
+            return
+        }
         try await self.restore(on: tx)
         self.copyPropertiesOf(otherEntity: AnnotationTextEntity.fromModel(annotationText))
         try await self.update(on: tx).get()

--- a/AnnotatoBackend/Sources/App/Models/Extensions/DocumentEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/DocumentEntity+CRUD.swift
@@ -20,6 +20,11 @@ extension DocumentEntity {
     ///   - tx: The database instance in a transaction.
     ///   - document: The updated Document instance.
     func customUpdate(on tx: Database, usingUpdatedModel document: Document) async throws {
+        if document.isDeleted && !self.isDeleted {
+            try await self.customDelete(on: tx)
+            return
+        }
+
         if document.isDeleted {
             return
         }

--- a/AnnotatoBackend/Sources/App/Models/Extensions/DocumentEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/DocumentEntity+CRUD.swift
@@ -30,7 +30,7 @@ extension DocumentEntity {
         self.copyPropertiesOf(otherEntity: DocumentEntity.fromModel(document))
 
         for annotation in document.annotations {
-            if let annotationEntity = try await AnnotationEntity.findIncludingDeleted(annotation.id, on: tx).get() {
+            if let annotationEntity = try await AnnotationEntity.findWithDeleted(annotation.id, on: tx).get() {
                 try await annotationEntity.customUpdate(on: tx, usingUpdatedModel: annotation)
             } else {
                 let annotationEntity = AnnotationEntity.fromModel(annotation)

--- a/AnnotatoBackend/Sources/App/Models/Extensions/DocumentEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/DocumentEntity+CRUD.swift
@@ -44,7 +44,8 @@ extension DocumentEntity {
     /// Deletes the DocumentEntity instance. Use this function to cascade deletes.
     /// - Parameter tx: The database instance in a transaction.
     func customDelete(on tx: Database) async throws {
-        try await self.loadAssociations(on: tx)
+        try await self.restore(on: tx)
+        try await self.loadAssociationsWithDeleted(on: tx)
 
         for annotationEntity in annotationEntities {
             try await annotationEntity.customDelete(on: tx)
@@ -58,6 +59,14 @@ extension DocumentEntity {
 
         for annotationEntity in self.annotationEntities {
             try await annotationEntity.loadAssociations(on: db)
+        }
+    }
+
+    func loadAssociationsWithDeleted(on db: Database) async throws {
+        try await self.$annotationEntities.loadWithDeleted(on: db).get()
+
+        for annotationEntity in self.annotationEntities {
+            try await annotationEntity.loadAssociationsWithDeleted(on: db)
         }
     }
 

--- a/AnnotatoBackend/Sources/App/Models/Extensions/SelectionBoxEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/SelectionBoxEntity+CRUD.swift
@@ -13,6 +13,11 @@ extension SelectionBoxEntity {
     ///   - tx: The database instance in a transaction.
     ///   - selectionBox: The updated SelectionBox instance.
     func customUpdate(on tx: Database, usingUpdatedModel selectionBox: SelectionBox) async throws {
+        if selectionBox.isDeleted {
+            return
+        }
+
+        try await self.restore(on: tx)
         self.copyPropertiesOf(otherEntity: SelectionBoxEntity.fromModel(selectionBox))
         try await self.update(on: tx).get()
     }

--- a/AnnotatoBackend/Sources/App/Models/Extensions/SelectionBoxEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/SelectionBoxEntity+CRUD.swift
@@ -13,6 +13,11 @@ extension SelectionBoxEntity {
     ///   - tx: The database instance in a transaction.
     ///   - selectionBox: The updated SelectionBox instance.
     func customUpdate(on tx: Database, usingUpdatedModel selectionBox: SelectionBox) async throws {
+        if selectionBox.isDeleted && !self.isDeleted {
+            try await self.customDelete(on: tx)
+            return
+        }
+
         if selectionBox.isDeleted {
             return
         }

--- a/AnnotatoBackend/Sources/App/Models/Extensions/SelectionBoxEntity+CRUD.swift
+++ b/AnnotatoBackend/Sources/App/Models/Extensions/SelectionBoxEntity+CRUD.swift
@@ -25,6 +25,7 @@ extension SelectionBoxEntity {
     /// Deletes the SelectionBoxEntity instance.
     /// - Parameter tx: The database instance in a transaction.
     func customDelete(on tx: Database) async throws {
+        try await self.restore(on: tx)
         try await self.delete(on: tx).get()
     }
 

--- a/AnnotatoBackend/Sources/App/Models/SelectionBoxEntity.swift
+++ b/AnnotatoBackend/Sources/App/Models/SelectionBoxEntity.swift
@@ -31,6 +31,10 @@ final class SelectionBoxEntity: Model {
     @Timestamp(key: "deleted_at", on: .delete)
     var deletedAt: Date?
 
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     init() { }
 
     init(

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
@@ -15,13 +15,13 @@ class AnnotationWebSocketController {
 
             switch message.subtype {
             case .createAnnotation:
-                await Self.handleCreateAnnotation(userId: userId, db: db, annotation: annotation)
+                _ = await Self.handleCreateAnnotation(userId: userId, db: db, annotation: annotation)
             case .readAnnotation:
                 await Self.handleReadAnnotation(userId: userId, db: db, annotation: annotation)
             case .updateAnnotation:
-                await Self.handleUpdateAnnotation(userId: userId, db: db, annotation: annotation)
+                _ = await Self.handleUpdateAnnotation(userId: userId, db: db, annotation: annotation)
             case .deleteAnnotation:
-                await Self.handleDeleteAnnotation(userId: userId, db: db, annotation: annotation)
+                _ = await Self.handleDeleteAnnotation(userId: userId, db: db, annotation: annotation)
             }
 
         } catch {
@@ -33,7 +33,7 @@ class AnnotationWebSocketController {
         userId: String,
         db: Database,
         annotation: Annotation
-    ) async {
+    ) async -> Annotation? {
         do {
             Self.logger.info("Processing create annotation data...")
 
@@ -44,8 +44,10 @@ class AnnotationWebSocketController {
                 db: db, userId: userId, annotation: newAnnotation, message: response
             )
 
+            return newAnnotation
         } catch {
             Self.logger.error("Error when creating annotation. \(error.localizedDescription)")
+            return nil
         }
     }
 
@@ -73,7 +75,7 @@ class AnnotationWebSocketController {
         userId: String,
         db: Database,
         annotation: Annotation
-    ) async {
+    ) async -> Annotation? {
         do {
             Self.logger.info("Processing update annotation data...")
 
@@ -85,8 +87,10 @@ class AnnotationWebSocketController {
                 db: db, userId: userId, annotation: updatedAnnotation, message: response
             )
 
+            return updatedAnnotation
         } catch {
             Self.logger.error("Error when updating annotation. \(error.localizedDescription)")
+            return nil
         }
     }
 
@@ -94,7 +98,7 @@ class AnnotationWebSocketController {
         userId: String,
         db: Database,
         annotation: Annotation
-    ) async {
+    ) async -> Annotation? {
         do {
             Self.logger.info("Processing delete annotation data...")
 
@@ -105,40 +109,32 @@ class AnnotationWebSocketController {
                 db: db, userId: userId, annotation: deletedAnnotation, message: response
             )
 
+            return deletedAnnotation
         } catch {
             Self.logger.error("Error when deleting annotation. \(error.localizedDescription)")
+            return nil
         }
     }
 
     static func handleOverrideServerAnnotations(
-        userId: String, db: Database, annotations: [Annotation]
+        userId: String,
+        db: Database,
+        annotations: [Annotation]
     ) async throws -> [Annotation] {
         var responseAnnotations: [Annotation] = []
 
         for annotation in annotations {
-            let resolvedAnnotation: Annotation
-            let responseToOtherClients: AnnotatoCrudAnnotationMessage
+            let resolvedAnnotation: Annotation?
 
             if annotation.isDeleted {
-                resolvedAnnotation = try await AnnotationDataAccess.delete(
-                    db: db, annotationId: annotation.id)
-                responseToOtherClients = AnnotatoCrudAnnotationMessage(
-                    subtype: .deleteAnnotation, annotation: resolvedAnnotation)
+                resolvedAnnotation = await Self.handleDeleteAnnotation(userId: userId, db: db, annotation: annotation)
             } else if await AnnotationDataAccess.canFindWithDeleted(db: db, annotationId: annotation.id) {
-                resolvedAnnotation = try await AnnotationDataAccess.update(
-                    db: db, annotationId: annotation.id, annotation: annotation)
-                responseToOtherClients = AnnotatoCrudAnnotationMessage(
-                    subtype: .updateAnnotation, annotation: resolvedAnnotation)
+                resolvedAnnotation = await Self.handleUpdateAnnotation(userId: userId, db: db, annotation: annotation)
             } else {
-                resolvedAnnotation = try await AnnotationDataAccess.create(db: db, annotation: annotation)
-                responseToOtherClients = AnnotatoCrudAnnotationMessage(
-                    subtype: .createAnnotation, annotation: resolvedAnnotation)
+                resolvedAnnotation = await Self.handleCreateAnnotation(userId: userId, db: db, annotation: annotation)
             }
 
-            await AnnotationWebSocketController.sendToAllAppropriateClients(
-                db: db, userId: userId, annotation: resolvedAnnotation, message: responseToOtherClients
-            )
-            responseAnnotations.append(resolvedAnnotation)
+            responseAnnotations.appendIfNotNil(resolvedAnnotation)
         }
 
         return responseAnnotations

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
@@ -110,7 +110,7 @@ class AnnotationWebSocketController {
         }
     }
 
-    private static func sendToAllAppropriateClients<T: Codable>(
+    static func sendToAllAppropriateClients<T: Codable>(
         db: Database,
         userId: String,
         annotation: Annotation,

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
@@ -116,18 +116,6 @@ class AnnotationWebSocketController {
         }
     }
 
-    static func handleKeepServerAnnotations(
-        userId: String, db: Database, annotations: [Annotation]
-    ) async -> [Annotation] {
-        do {
-            let annotationIds = annotations.map { $0.id }
-            return try await AnnotationDataAccess.listWithDeleted(db: db, annotationIds: annotationIds)
-        } catch {
-            Self.logger.error("Error when fetching server annotations. \(error.localizedDescription)")
-            return []
-        }
-    }
-
     static func handleOverrideServerAnnotations(
         userId: String,
         db: Database,

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/AnnotationWebSocketController.swift
@@ -116,11 +116,23 @@ class AnnotationWebSocketController {
         }
     }
 
+    static func handleKeepServerAnnotations(
+        userId: String, db: Database, annotations: [Annotation]
+    ) async -> [Annotation] {
+        do {
+            let annotationIds = annotations.map { $0.id }
+            return try await AnnotationDataAccess.listWithDeleted(db: db, annotationIds: annotationIds)
+        } catch {
+            Self.logger.error("Error when fetching server annotations. \(error.localizedDescription)")
+            return []
+        }
+    }
+
     static func handleOverrideServerAnnotations(
         userId: String,
         db: Database,
         annotations: [Annotation]
-    ) async throws -> [Annotation] {
+    ) async -> [Annotation] {
         var responseAnnotations: [Annotation] = []
 
         for annotation in annotations {

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
@@ -102,7 +102,7 @@ class DocumentWebSocketController {
         userId: String,
         db: Database,
         message: AnnotatoOfflineToOnlineMessage
-    ) async -> [Document] {
+    ) async throws -> [Document] {
         var responseDocuments: [Document] = []
 
         for document in message.documents {
@@ -123,7 +123,7 @@ class DocumentWebSocketController {
             .listEntitiesCreatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt, userId: userId)
 
         for document in newServerDocumentsWhileOffline {
-            _ = await Self.handleDeleteDocument(userId: userId, db: db, document: Document)
+            _ = await Self.handleDeleteDocument(userId: userId, db: db, document: document)
         }
 
         return responseDocuments

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
@@ -99,7 +99,9 @@ class DocumentWebSocketController {
     }
 
     static func handleOverrideServerDocuments(
-        userId: String, db: Database, documents: [Document]
+        userId: String,
+        db: Database,
+        documents: [Document]
     ) async -> [Document] {
         var responseDocuments: [Document] = []
 

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
@@ -98,9 +98,21 @@ class DocumentWebSocketController {
         }
     }
 
+    static func handleKeepServerDocuments(
+        userId: String, db: Database, documents: [Document]
+    ) async -> [Document] {
+        do {
+            let documentIds = documents.map { $0.id }
+            return try await DocumentsDataAccess.listWithDeleted(db: db, documentIds: documentIds)
+        } catch {
+            Self.logger.error("Error when fetching server documents. \(error.localizedDescription)")
+            return []
+        }
+    }
+
     static func handleOverrideServerDocuments(
         userId: String, db: Database, documents: [Document]
-    ) async throws -> [Document] {
+    ) async -> [Document] {
         var responseDocuments: [Document] = []
 
         for document in documents {

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
@@ -98,18 +98,6 @@ class DocumentWebSocketController {
         }
     }
 
-    static func handleKeepServerDocuments(
-        userId: String, db: Database, documents: [Document]
-    ) async -> [Document] {
-        do {
-            let documentIds = documents.map { $0.id }
-            return try await DocumentsDataAccess.listWithDeleted(db: db, documentIds: documentIds)
-        } catch {
-            Self.logger.error("Error when fetching server documents. \(error.localizedDescription)")
-            return []
-        }
-    }
-
     static func handleOverrideServerDocuments(
         userId: String, db: Database, documents: [Document]
     ) async -> [Document] {

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/DocumentWebSocketController.swift
@@ -93,7 +93,7 @@ class DocumentWebSocketController {
         }
     }
 
-    private static func sendToAllAppropriateClients<T: Codable>(
+    static func sendToAllAppropriateClients<T: Codable>(
         db: Database,
         userId: String,
         document: Document,

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Vapor
+import AnnotatoSharedLibrary
+import FluentKit
+
+class OfflineToOnlineWebSocketController {
+    private static var logger = Logger(label: "OfflineToOnlineWebSocketController")
+
+    static func handleOfflineToOnlineResolution(userId: String, data: Data, db: Database) async {
+        do {
+            Self.logger.info("Processing offline to online data...")
+
+            let message = try JSONDecoder().decode(AnnotatoOfflineToOnlineMessage.self, from: data)
+
+            switch message.mergeStrategy {
+            case .duplicateConflicts:
+                print("duplicate conflicts")
+            case .keepServerVersion:
+                print("keep server version")
+            case .overrideServerVersion:
+                print("override server version")
+            }
+        } catch {
+            Self.logger.error("Error when handling incoming offline to online data. \(error.localizedDescription)")
+        }
+    }
+}

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -66,18 +66,11 @@ class OfflineToOnlineWebSocketController {
         do {
             Self.logger.info("Processing override server data...")
 
-            let overriddenDocuments = await DocumentWebSocketController
-                .handleOverrideServerDocuments(userId: userId, db: db, documents: message.documents)
+            let responseDocuments = try await DocumentWebSocketController
+                .handleOverrideServerDocuments(userId: userId, db: db, message: message)
 
-            let responseDocuments = overriddenDocuments
-
-            let overriddenAnnotations = await AnnotationWebSocketController
-                .handleOverrideServerAnnotations(userId: userId, db: db, annotations: message.annotations)
-
-            let newServerAnnotationsWhileOffline = try await AnnotationDataAccess
-                .listEntitiesCreatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt, userId: userId)
-
-            let responseAnnotations = overriddenAnnotations + newServerAnnotationsWhileOffline
+            let responseAnnotations = try await AnnotationWebSocketController
+                .handleOverrideServerAnnotations(userId: userId, db: db, message: message)
 
             let response = AnnotatoOfflineToOnlineMessage(
                 mergeStrategy: .overrideServerVersion,

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -34,45 +34,96 @@ class OfflineToOnlineWebSocketController {
         do {
             Self.logger.info("Processing override server data...")
 
-            let documents = message.documents
-            var responseDocuments: [Document] = []
+            let responseDocuments: [Document] = try await handleOverrideServerDocuments(
+                userId: userId, db: db, documents: message.documents)
 
-            for document in documents {
-                let resolvedDocument: Document
+            let responseAnnotations: [Annotation] = try await handleOverrideServerAnnotations(
+                userId: userId, db: db, annotations: message.annotations)
 
-                if document.isDeleted {
-                    resolvedDocument = try await DocumentsDataAccess.delete(
-                        db: db, documentId: document.id)
-                } else if await DocumentsDataAccess.canFindWithDeleted(db: db, documentId: document.id) {
-                    resolvedDocument = try await DocumentsDataAccess.update(
-                        db: db, documentId: document.id, document: document)
-                } else {
-                    resolvedDocument = try await DocumentsDataAccess.create(db: db, document: document)
-                }
+            let response = AnnotatoOfflineToOnlineMessage(
+                mergeStrategy: .overrideServerVersion,
+                documents: responseDocuments,
+                annotations: responseAnnotations
+            )
 
-                responseDocuments.append(resolvedDocument)
-            }
-
-            let annotations = message.annotations
-            var responseAnnotations: [Annotation] = []
-
-            for annotation in annotations {
-                let resolvedAnnotation: Annotation
-
-                if annotation.isDeleted {
-                    resolvedAnnotation = try await AnnotationDataAccess.delete(
-                        db: db, annotationId: annotation.id)
-                } else if await AnnotationDataAccess.canFindWithDeleted(db: db, annotationId: annotation.id) {
-                    resolvedAnnotation = try await AnnotationDataAccess.update(
-                        db: db, annotationId: annotation.id, annotation: annotation)
-                } else {
-                    resolvedAnnotation = try await AnnotationDataAccess.create(db: db, annotation: annotation)
-                }
-
-                responseAnnotations.append(resolvedAnnotation)
-            }
+            await Self.sendBackToSender(userId: userId, message: response)
         } catch {
             Self.logger.error("Error when overriding server version. \(error.localizedDescription)")
+        }
+    }
+
+    private static func handleOverrideServerDocuments(
+        userId: String, db: Database, documents: [Document]) async throws -> [Document] {
+        var responseDocuments: [Document] = []
+
+        for document in documents {
+            let resolvedDocument: Document
+            let responseToOtherClients: AnnotatoCrudDocumentMessage
+
+            if document.isDeleted {
+                resolvedDocument = try await DocumentsDataAccess.delete(
+                    db: db, documentId: document.id)
+                responseToOtherClients = AnnotatoCrudDocumentMessage(
+                    subtype: .deleteDocument, document: resolvedDocument)
+            } else if await DocumentsDataAccess.canFindWithDeleted(db: db, documentId: document.id) {
+                resolvedDocument = try await DocumentsDataAccess.update(
+                    db: db, documentId: document.id, document: document)
+                responseToOtherClients = AnnotatoCrudDocumentMessage(
+                    subtype: .updateDocument, document: resolvedDocument)
+            } else {
+                resolvedDocument = try await DocumentsDataAccess.create(db: db, document: document)
+                responseToOtherClients = AnnotatoCrudDocumentMessage(
+                    subtype: .createDocument, document: resolvedDocument)
+            }
+
+            await DocumentWebSocketController.sendToAllAppropriateClients(
+                db: db, userId: userId, document: resolvedDocument, message: responseToOtherClients
+            )
+            responseDocuments.append(resolvedDocument)
+        }
+        return responseDocuments
+    }
+
+    private static func handleOverrideServerAnnotations(
+        userId: String, db: Database, annotations: [Annotation]) async throws -> [Annotation] {
+        var responseAnnotations: [Annotation] = []
+
+        for annotation in annotations {
+            let resolvedAnnotation: Annotation
+            let responseToOtherClients: AnnotatoCrudAnnotationMessage
+
+            if annotation.isDeleted {
+                resolvedAnnotation = try await AnnotationDataAccess.delete(
+                    db: db, annotationId: annotation.id)
+                responseToOtherClients = AnnotatoCrudAnnotationMessage(
+                    subtype: .deleteAnnotation, annotation: resolvedAnnotation)
+            } else if await AnnotationDataAccess.canFindWithDeleted(db: db, annotationId: annotation.id) {
+                resolvedAnnotation = try await AnnotationDataAccess.update(
+                    db: db, annotationId: annotation.id, annotation: annotation)
+                responseToOtherClients = AnnotatoCrudAnnotationMessage(
+                    subtype: .updateAnnotation, annotation: resolvedAnnotation)
+            } else {
+                resolvedAnnotation = try await AnnotationDataAccess.create(db: db, annotation: annotation)
+                responseToOtherClients = AnnotatoCrudAnnotationMessage(
+                    subtype: .createAnnotation, annotation: resolvedAnnotation)
+            }
+
+            await AnnotationWebSocketController.sendToAllAppropriateClients(
+                db: db, userId: userId, annotation: resolvedAnnotation, message: responseToOtherClients
+            )
+            responseAnnotations.append(resolvedAnnotation)
+        }
+
+        return responseAnnotations
+    }
+
+    private static func sendBackToSender<T: Codable>(userId: String, message: T) async {
+        do {
+            Self.logger.info("Sending offline to online resolution back to sender...")
+
+            WebSocketController.sendAll(recipientIds: [userId], message: message)
+        } catch {
+            Self.logger.error("Error when sending response to users. \(error.localizedDescription)")
         }
     }
 }

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -43,7 +43,7 @@ class OfflineToOnlineWebSocketController {
                 if document.isDeleted {
                     resolvedDocument = try await DocumentsDataAccess.delete(
                         db: db, documentId: document.id)
-                } else if await DocumentsDataAccess.canFindIncludingDeleted(db: db, documentId: document.id) {
+                } else if await DocumentsDataAccess.canFindWithDeleted(db: db, documentId: document.id) {
                     resolvedDocument = try await DocumentsDataAccess.update(
                         db: db, documentId: document.id, document: document)
                 } else {
@@ -62,7 +62,7 @@ class OfflineToOnlineWebSocketController {
                 if annotation.isDeleted {
                     resolvedAnnotation = try await AnnotationDataAccess.delete(
                         db: db, annotationId: annotation.id)
-                } else if await AnnotationDataAccess.canFindIncludingDeleted(db: db, annotationId: annotation.id) {
+                } else if await AnnotationDataAccess.canFindWithDeleted(db: db, annotationId: annotation.id) {
                     resolvedAnnotation = try await AnnotationDataAccess.update(
                         db: db, annotationId: annotation.id, annotation: annotation)
                 } else {

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -13,8 +13,6 @@ class OfflineToOnlineWebSocketController {
             let message = try JSONCustomDecoder().decode(AnnotatoOfflineToOnlineMessage.self, from: data)
 
             switch message.mergeStrategy {
-            case .duplicateConflicts:
-                print("duplicate conflicts")
             case .keepServerVersion:
                 await handleKeepServerVersion(userId: userId, db: db, message: message)
             case .overrideServerVersion:
@@ -69,8 +67,8 @@ class OfflineToOnlineWebSocketController {
             let overriddenAnnotations = await AnnotationWebSocketController
                 .handleOverrideServerAnnotations(userId: userId, db: db, annotations: message.annotations)
 
-            let newServerAnnotationsWhileOffline = try await AnnotationDataAccess.listEntitiesCreatedAfterDateWithDeleted(
-                db: db, date: message.lastOnlineAt)
+            let newServerAnnotationsWhileOffline = try await AnnotationDataAccess
+                .listEntitiesCreatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt)
 
             let responseAnnotations = overriddenAnnotations + newServerAnnotationsWhileOffline
 

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -18,10 +18,37 @@ class OfflineToOnlineWebSocketController {
             case .keepServerVersion:
                 print("keep server version")
             case .overrideServerVersion:
-                print("override server version")
+                await Self.handleOverrideServerVersion(userId: userId, db: db, message: message)
             }
         } catch {
             Self.logger.error("Error when handling incoming offline to online data. \(error.localizedDescription)")
+        }
+    }
+
+    private static func handleOverrideServerVersion(
+        userId: String,
+        db: Database,
+        message: AnnotatoOfflineToOnlineMessage
+    ) async {
+        do {
+            Self.logger.info("Processing override server data...")
+
+            let documents = message.documents
+            var responseDocuments: [Document] = []
+
+            for document in documents {
+                if await DocumentsDataAccess.isFoundIncludingDeleted(db: db, documentId: document.id) {
+                    // TODO: Restore/Update deleted at after payload includes it
+                    let updatedDocument = try await DocumentsDataAccess.update(
+                        db: db, documentId: document.id, document: document)
+                    responseDocuments.append(updatedDocument)
+                } else {
+                    let newDocument = try await DocumentsDataAccess.create(db: db, document: document)
+                    responseDocuments.append(newDocument)
+                }
+            }
+        } catch {
+            Self.logger.error("Error when overriding server version. \(error.localizedDescription)")
         }
     }
 }

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -34,11 +34,11 @@ class OfflineToOnlineWebSocketController {
         do {
             Self.logger.info("Processing override server data...")
 
-            let responseDocuments: [Document] = try await handleOverrideServerDocuments(
-                userId: userId, db: db, documents: message.documents)
+            let responseDocuments: [Document] = try await DocumentWebSocketController
+                .handleOverrideServerDocuments(userId: userId, db: db, documents: message.documents)
 
-            let responseAnnotations: [Annotation] = try await handleOverrideServerAnnotations(
-                userId: userId, db: db, annotations: message.annotations)
+            let responseAnnotations: [Annotation] = try await AnnotationWebSocketController
+                .handleOverrideServerAnnotations(userId: userId, db: db, annotations: message.annotations)
 
             let response = AnnotatoOfflineToOnlineMessage(
                 mergeStrategy: .overrideServerVersion,
@@ -52,78 +52,9 @@ class OfflineToOnlineWebSocketController {
         }
     }
 
-    private static func handleOverrideServerDocuments(
-        userId: String, db: Database, documents: [Document]) async throws -> [Document] {
-        var responseDocuments: [Document] = []
-
-        for document in documents {
-            let resolvedDocument: Document
-            let responseToOtherClients: AnnotatoCrudDocumentMessage
-
-            if document.isDeleted {
-                resolvedDocument = try await DocumentsDataAccess.delete(
-                    db: db, documentId: document.id)
-                responseToOtherClients = AnnotatoCrudDocumentMessage(
-                    subtype: .deleteDocument, document: resolvedDocument)
-            } else if await DocumentsDataAccess.canFindWithDeleted(db: db, documentId: document.id) {
-                resolvedDocument = try await DocumentsDataAccess.update(
-                    db: db, documentId: document.id, document: document)
-                responseToOtherClients = AnnotatoCrudDocumentMessage(
-                    subtype: .updateDocument, document: resolvedDocument)
-            } else {
-                resolvedDocument = try await DocumentsDataAccess.create(db: db, document: document)
-                responseToOtherClients = AnnotatoCrudDocumentMessage(
-                    subtype: .createDocument, document: resolvedDocument)
-            }
-
-            await DocumentWebSocketController.sendToAllAppropriateClients(
-                db: db, userId: userId, document: resolvedDocument, message: responseToOtherClients
-            )
-            responseDocuments.append(resolvedDocument)
-        }
-        return responseDocuments
-    }
-
-    private static func handleOverrideServerAnnotations(
-        userId: String, db: Database, annotations: [Annotation]) async throws -> [Annotation] {
-        var responseAnnotations: [Annotation] = []
-
-        for annotation in annotations {
-            let resolvedAnnotation: Annotation
-            let responseToOtherClients: AnnotatoCrudAnnotationMessage
-
-            if annotation.isDeleted {
-                resolvedAnnotation = try await AnnotationDataAccess.delete(
-                    db: db, annotationId: annotation.id)
-                responseToOtherClients = AnnotatoCrudAnnotationMessage(
-                    subtype: .deleteAnnotation, annotation: resolvedAnnotation)
-            } else if await AnnotationDataAccess.canFindWithDeleted(db: db, annotationId: annotation.id) {
-                resolvedAnnotation = try await AnnotationDataAccess.update(
-                    db: db, annotationId: annotation.id, annotation: annotation)
-                responseToOtherClients = AnnotatoCrudAnnotationMessage(
-                    subtype: .updateAnnotation, annotation: resolvedAnnotation)
-            } else {
-                resolvedAnnotation = try await AnnotationDataAccess.create(db: db, annotation: annotation)
-                responseToOtherClients = AnnotatoCrudAnnotationMessage(
-                    subtype: .createAnnotation, annotation: resolvedAnnotation)
-            }
-
-            await AnnotationWebSocketController.sendToAllAppropriateClients(
-                db: db, userId: userId, annotation: resolvedAnnotation, message: responseToOtherClients
-            )
-            responseAnnotations.append(resolvedAnnotation)
-        }
-
-        return responseAnnotations
-    }
-
     private static func sendBackToSender<T: Codable>(userId: String, message: T) async {
-        do {
-            Self.logger.info("Sending offline to online resolution back to sender...")
+        Self.logger.info("Sending offline to online resolution back to sender...")
 
-            WebSocketController.sendAll(recipientIds: [userId], message: message)
-        } catch {
-            Self.logger.error("Error when sending response to users. \(error.localizedDescription)")
-        }
+        WebSocketController.sendAll(recipientIds: [userId], message: message)
     }
 }

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -30,10 +30,10 @@ class OfflineToOnlineWebSocketController {
     ) async {
         do {
             let responseDocuments = try await DocumentsDataAccess
-                .listEntitiesUpdatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt)
+                .listEntitiesUpdatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt, userId: userId)
 
             let responseAnnotations = try await AnnotationDataAccess
-                .listEntitiesUpdatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt)
+                .listEntitiesUpdatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt, userId: userId)
 
             let response = AnnotatoOfflineToOnlineMessage(
                 mergeStrategy: .keepServerVersion,
@@ -59,16 +59,13 @@ class OfflineToOnlineWebSocketController {
             let overriddenDocuments = await DocumentWebSocketController
                 .handleOverrideServerDocuments(userId: userId, db: db, documents: message.documents)
 
-            let newServerDocumentsWhileOffline = try await DocumentsDataAccess
-                .listEntitiesCreatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt)
-
-            let responseDocuments = overriddenDocuments + newServerDocumentsWhileOffline
+            let responseDocuments = overriddenDocuments
 
             let overriddenAnnotations = await AnnotationWebSocketController
                 .handleOverrideServerAnnotations(userId: userId, db: db, annotations: message.annotations)
 
             let newServerAnnotationsWhileOffline = try await AnnotationDataAccess
-                .listEntitiesCreatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt)
+                .listEntitiesCreatedAfterDateWithDeleted(db: db, date: message.lastOnlineAt, userId: userId)
 
             let responseAnnotations = overriddenAnnotations + newServerAnnotationsWhileOffline
 

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/OfflineToOnlineWebSocketController.swift
@@ -10,7 +10,7 @@ class OfflineToOnlineWebSocketController {
         do {
             Self.logger.info("Processing offline to online data...")
 
-            let message = try JSONDecoder().decode(AnnotatoOfflineToOnlineMessage.self, from: data)
+            let message = try JSONCustomDecoder().decode(AnnotatoOfflineToOnlineMessage.self, from: data)
 
             switch message.mergeStrategy {
             case .duplicateConflicts:
@@ -21,6 +21,7 @@ class OfflineToOnlineWebSocketController {
                 await Self.handleOverrideServerVersion(userId: userId, db: db, message: message)
             }
         } catch {
+            print(String(describing: error))
             Self.logger.error("Error when handling incoming offline to online data. \(error.localizedDescription)")
         }
     }
@@ -37,15 +38,38 @@ class OfflineToOnlineWebSocketController {
             var responseDocuments: [Document] = []
 
             for document in documents {
-                if await DocumentsDataAccess.isFoundIncludingDeleted(db: db, documentId: document.id) {
-                    // TODO: Restore/Update deleted at after payload includes it
-                    let updatedDocument = try await DocumentsDataAccess.update(
+                let resolvedDocument: Document
+
+                if document.isDeleted {
+                    resolvedDocument = try await DocumentsDataAccess.delete(
+                        db: db, documentId: document.id)
+                } else if await DocumentsDataAccess.canFindIncludingDeleted(db: db, documentId: document.id) {
+                    resolvedDocument = try await DocumentsDataAccess.update(
                         db: db, documentId: document.id, document: document)
-                    responseDocuments.append(updatedDocument)
                 } else {
-                    let newDocument = try await DocumentsDataAccess.create(db: db, document: document)
-                    responseDocuments.append(newDocument)
+                    resolvedDocument = try await DocumentsDataAccess.create(db: db, document: document)
                 }
+
+                responseDocuments.append(resolvedDocument)
+            }
+
+            let annotations = message.annotations
+            var responseAnnotations: [Annotation] = []
+
+            for annotation in annotations {
+                let resolvedAnnotation: Annotation
+
+                if annotation.isDeleted {
+                    resolvedAnnotation = try await AnnotationDataAccess.delete(
+                        db: db, annotationId: annotation.id)
+                } else if await AnnotationDataAccess.canFindIncludingDeleted(db: db, annotationId: annotation.id) {
+                    resolvedAnnotation = try await AnnotationDataAccess.update(
+                        db: db, annotationId: annotation.id, annotation: annotation)
+                } else {
+                    resolvedAnnotation = try await AnnotationDataAccess.create(db: db, annotation: annotation)
+                }
+
+                responseAnnotations.append(resolvedAnnotation)
             }
         } catch {
             Self.logger.error("Error when overriding server version. \(error.localizedDescription)")

--- a/AnnotatoBackend/Sources/App/WebSocketControllers/WebSocketController.swift
+++ b/AnnotatoBackend/Sources/App/WebSocketControllers/WebSocketController.swift
@@ -75,9 +75,9 @@ class WebSocketController {
             case .crudAnnotation:
                 await AnnotationWebSocketController.handleCrudAnnotationData(userId: userId, data: data, db: db)
             case .offlineToOnline:
-                print("Not implemented yet. Do nothing.")
+                await OfflineToOnlineWebSocketController.handleOfflineToOnlineResolution(
+                    userId: userId, data: data, db: db)
             }
-
         } catch {
             Self.logger.error("Error when handling incoming data. \(error.localizedDescription)")
         }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
@@ -320,3 +320,15 @@ extension Annotation {
         }
     }
 }
+
+extension Annotation: Equatable {
+    public static func == (lhs: Annotation, rhs: Annotation) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+extension Annotation: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Annotation.swift
@@ -12,6 +12,10 @@ public final class Annotation: Codable, ObservableObject {
     public private(set) var updatedAt: Date?
     public private(set) var deletedAt: Date?
 
+    public var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     @Published public private(set) var origin: CGPoint
     @Published public private(set) var addedTextPart: AnnotationText?
     @Published public private(set) var addedMarkdownPart: AnnotationText?

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationHandwriting.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationHandwriting.swift
@@ -16,6 +16,10 @@ public final class AnnotationHandwriting: Codable, AnnotationPart {
         (try? PKDrawing(data: handwriting).bounds.isEmpty) ?? false
     }
 
+    public var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     @Published public private(set) var isRemoved = false
 
     public required init(

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationText.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/AnnotationText.swift
@@ -16,6 +16,10 @@ public final class AnnotationText: Codable, AnnotationPart {
         content.isEmpty
     }
 
+    public var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     @Published public private(set) var isRemoved = false
 
     public required init(

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Document.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Document.swift
@@ -76,3 +76,15 @@ extension Document: CustomStringConvertible {
         "deleteAt: \(String(describing: deletedAt))"
     }
 }
+
+extension Document: Equatable {
+    public static func == (lhs: Document, rhs: Document) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+extension Document: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Document.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Document.swift
@@ -10,6 +10,10 @@ public final class Document: Codable {
     public private(set) var updatedAt: Date?
     public private(set) var deletedAt: Date?
 
+    public var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     public required init(
         name: String,
         ownerId: String,

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/SelectionBox.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/SelectionBox.swift
@@ -10,6 +10,10 @@ public final class SelectionBox: Codable, ObservableObject {
     public private(set) var updatedAt: Date?
     public private(set) var deletedAt: Date?
 
+    public var isDeleted: Bool {
+        deletedAt != nil
+    }
+
     @Published public private(set) var endPoint: CGPoint
 
     public required init(

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/WebSocket/AnnotatoMessageType.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/WebSocket/AnnotatoMessageType.swift
@@ -21,7 +21,6 @@ public enum AnnotatoCrudAnnotationMessageType: String, Codable {
 
 /// Merge Strategies of `AnnotatoOfflineToOnlineMessage`
 public enum AnnotatoOfflineToOnlineMergeStrategy: String, Codable {
-    case duplicateConflicts
     case overrideServerVersion
     case keepServerVersion
 }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/WebSocket/AnnotatoOfflineToOnlineMessage.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/WebSocket/AnnotatoOfflineToOnlineMessage.swift
@@ -1,15 +1,20 @@
+import Foundation
+
 public class AnnotatoOfflineToOnlineMessage: Codable {
     public private(set) var type = AnnotatoMessageType.offlineToOnline
     public let mergeStrategy: AnnotatoOfflineToOnlineMergeStrategy
+    public let lastOnlineAt: Date
     public let documents: [Document]
     public let annotations: [Annotation]
 
     public required init(
         mergeStrategy: AnnotatoOfflineToOnlineMergeStrategy,
+        lastOnlineAt: Date,
         documents: [Document] = [],
         annotations: [Annotation] = []
     ) {
         self.mergeStrategy = mergeStrategy
+        self.lastOnlineAt = lastOnlineAt
         self.documents = documents
         self.annotations = annotations
     }
@@ -18,6 +23,6 @@ public class AnnotatoOfflineToOnlineMessage: Codable {
 extension AnnotatoOfflineToOnlineMessage: CustomDebugStringConvertible {
     public var debugDescription: String {
         "AnnotatoOfflineToOnlineMessage(type: \(type), mergeStrategy: \(mergeStrategy), " +
-        "documents: \(documents), annotations: \(annotations))"
+        "lastOnlineAt: \(lastOnlineAt), documents: \(documents), annotations: \(annotations))"
     }
 }


### PR DESCRIPTION
Considerations

- May not be necessary to implement duplicate, since it's extra work but we already have proof of concept (and still need to handle frontend resolution and integration :^(
- May need to move publishers out of view models. For example, if the server deletes an annotation, but the offline user chooses to override server and restore the it, other clients need to get the updated annotation back and re-render it. The other clients do not have the annotation view model at the moment to get the response through that (because they deleted it).
- Currently, does the user only locally persist `Document` that they have access to? I would think so right? If so we need to facilitate that import to local db whenever user imports a document from the shared code?

Invariants

- Server is the source of truth
  - So if user chooses to override server, when the server creates/updates/deletes using the server's payload, it creates a new timestamp at that moment
  - This works as our local persistence persists whatever the server tells it to persist. So after resolution, the local db is updated with the server's response.

## Tests

Keep Server Version

- [x] Should discard any updates sent by the user
- [x] Should not delete anything even if user deleted

Override Server Version

- [x] Should update server version with user version
- [x] If the server version was deleted, but the user did an update, it should restore the server version. (Check if timestamps are updated)