### PR TITLE
Fix connectivity

### DIFF
--- a/Annotato/Annotato/Views/Document/Edit/DocumentView.swift
+++ b/Annotato/Annotato/Views/Document/Edit/DocumentView.swift
@@ -131,6 +131,14 @@ class DocumentView: UIView {
 
     @objc
     private func didTap(_ sender: UITapGestureRecognizer) {
+        let isConnected = WebSocketManager.shared.isConnected
+        let lastOnlineTimeFromWebSocketManager = WebSocketManager.shared.getLastOnline()
+        let lastOnlineTimeFromUserDefaults = UserDefaults.standard.object(
+            forKey: "lastOnline")
+        print("isConnected: \(isConnected)")
+        print("lastOnlineTimeFromWebSocketManager: \(lastOnlineTimeFromWebSocketManager)")
+        print("lastOnlineTimeFromUserDefaults: \(lastOnlineTimeFromUserDefaults)")
+
         viewModel.setAllAnnotationsOutOfFocus()
 
         guard let pdfInnerDocumentView = pdfView.documentView else {

--- a/Annotato/Annotato/WebSocket/NetworkManager.swift
+++ b/Annotato/Annotato/WebSocket/NetworkManager.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Reachability
+
+class NetworkManager: NSObject {
+    var reachability: Reachability!
+    static let sharedInstance = NetworkManager()
+
+    override init() {
+        super.init()
+        // Initialise reachability
+        reachability = try? Reachability()
+        // Register an observer for the network status
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(networkStatusChanged(_:)),
+            name: .reachabilityChanged,
+            object: reachability
+        )
+        do {
+            // Start the network status notifier
+            try reachability.startNotifier()
+        } catch {
+            print("Unable to start notifier")
+        }
+    }
+
+    @objc
+    func networkStatusChanged(_ notification: Notification) {
+        print("Network status changed")
+        print(notification.description)
+    }
+}

--- a/Annotato/Annotato/WebSocket/WebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/WebSocketManager.swift
@@ -31,7 +31,22 @@ class WebSocketManager {
         listen()
         socket?.resume()
         pingServer()
-        timerTriggerToUpdateLastOnline()
+//        timerTriggerToUpdateLastOnline()
+        queryNetworkManager()
+        startTimerToQueryNetworkStatus()
+    }
+
+    private func startTimerToQueryNetworkStatus() {
+        Timer.scheduledTimer(withTimeInterval: 7.0, repeats: true, block: { _ in
+            print("Querying the network manager")
+            self.queryNetworkManager()
+        })
+    }
+
+    private func queryNetworkManager() {
+        let isConnected = NetworkManager.sharedInstance.reachability.connection != .unavailable
+        print("connection status: \(isConnected)")
+        print("Connectivity status: \(isConnected)")
     }
 
     func resetSocket() {
@@ -48,23 +63,29 @@ class WebSocketManager {
         }
         socket.sendPing(pongReceiveHandler: { [weak self] err in
             guard let self = self else {
+                print("Ponging self==self return")
                 return
             }
             if err == nil {
+                print("no error from pong")
                 self.isConnected = true
                 self.storeLastOnlineLocally(to: Date())
             } else {
+                print("error from pong")
                 self.isConnected = false
             }
         })
     }
 
     private func timerTriggerToUpdateLastOnline() {
-        Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true, block: { _ in
+        Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true, block: { _ in
+            print("Pinging the server")
             self.pingServer()
             if self.isConnected {
+                print("is connected, updating time")
                 self.storeLastOnlineLocally(to: Date())
             } else {
+                print("resetting socket and set up socket")
                 self.resetSocket()
                 self.setUpSocket()
             }

--- a/Annotato/Annotato/WebSocket/WebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/WebSocketManager.swift
@@ -98,12 +98,6 @@ class WebSocketManager {
             // We need to re-register the callback closure after a message is received
             self.listen()
         }
-        if self.isConnected {
-            AnnotatoLogger.info("Connected. Updating last online time")
-            self.storeLastOnlineLocally(to: Date())
-        } else {
-            AnnotatoLogger.info("Not connected, so not updating last online time")
-        }
     }
 
     func send<T: Codable>(message: T) {

--- a/Annotato/Annotato/WebSocket/WebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/WebSocketManager.swift
@@ -60,7 +60,7 @@ class WebSocketManager {
     }
 
     private func timerTriggerToUpdateLastOnline() {
-        Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true, block: { _ in
+        Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true, block: { _ in
             self.pingServer()
             if self.isConnected {
                 self.storeLastOnlineLocally(to: Date())


### PR DESCRIPTION
If we rely only on socket receive, then we will only get to know the connectivity when we use the web socket.

Hence I added in the additional timer to check connectivity every 60 seconds, and if we are not connected, then it will attempt to restore connection by resetSocket() and setUpSocket().

Now we have two mechanisms to detect when a user goes offline. One is if he edits something and triggers the websocket. This will throw a .failure, and we know that we are not connected.

Assuming the user goes offline but does nothing. Then the timer will detect it because it pings the server to test connectivity.

Note: Initially, I set a while true loop to update the lastOnline time of the user. I realized that it made my macbook extremely slow. So I added this updating to the timer. This means that the lastOnline of the user is correct with a plus minus of 60 seconds. Let me know if you guys prefer the while true loop

This is the code for the while true loop
```
   private func beginInfiniteLoopForLastOnlineUpdating() {
        DispatchQueue.global(qos: .background).async {
            while true {
                if self.isConnected {
                    self.storeLastOnlineLocally(to: Date())
                }
            }
        }
    }
```

Edit:
- Try to add the sleep to the while true block


Resolves #128 