### PR TITLE
Refactor websocket subscribers

### DIFF
--- a/Annotato/Annotato/ViewModels/SelectionBox/SelectionBoxViewModel.swift
+++ b/Annotato/Annotato/ViewModels/SelectionBox/SelectionBoxViewModel.swift
@@ -24,6 +24,10 @@ class SelectionBoxViewModel: ObservableObject {
     func didDelete() {
         self.isRemoved = true
     }
+
+    func receiveDelete() {
+        self.isRemoved = true
+    }
 }
 
 extension SelectionBoxViewModel {


### PR DESCRIPTION
- Moved them out to view controllers
- Use `receiveX` functions inside view models to prevent infinite cycles