### PR TITLE
Persist (remaining) remote responses locally

### DIFF
--- a/Annotato/Annotato/Controllers/DocumentShareController.swift
+++ b/Annotato/Annotato/Controllers/DocumentShareController.swift
@@ -2,13 +2,14 @@ import Foundation
 import AnnotatoSharedLibrary
 
 struct DocumentShareController {
-    static func createDocumentShare(documentId: UUID) async -> DocumentShare? {
+    static func createDocumentShare(documentId: UUID) async -> Document? {
         guard let currentUser = AnnotatoAuth().currentUser else {
             return nil
         }
 
         let documentShare = DocumentShare(documentId: documentId, recipientId: currentUser.uid)
 
-        return await RemoteDocumentSharesPersistence().createDocumentShare(documentShare: documentShare)
+        return await AnnotatoPersistenceWrapper.currentPersistenceService
+            .createDocumentShare(documentShare: documentShare)
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/AnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/AnnotationsPersistence.swift
@@ -4,6 +4,6 @@ protocol AnnotationsPersistence {
     func createAnnotation(annotation: Annotation) async -> Annotation?
     func updateAnnotation(annotation: Annotation) async -> Annotation?
     func deleteAnnotation(annotation: Annotation) async -> Annotation?
-    func createOrUpdateAnnotation(annotation: Annotation) -> Annotation?
-    func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]?
+    func createOrUpdateAnnotation(annotation: Annotation) async -> Annotation?
+    func createOrUpdateAnnotations(annotations: [Annotation]) async -> [Annotation]?
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/AnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/AnnotationsPersistence.swift
@@ -4,5 +4,6 @@ protocol AnnotationsPersistence {
     func createAnnotation(annotation: Annotation) async -> Annotation?
     func updateAnnotation(annotation: Annotation) async -> Annotation?
     func deleteAnnotation(annotation: Annotation) async -> Annotation?
+    func createOrUpdateAnnotation(annotation: Annotation) -> Annotation?
     func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]?
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/DocumentSharesPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/DocumentSharesPersistence.swift
@@ -1,5 +1,5 @@
 import AnnotatoSharedLibrary
 
 protocol DocumentSharesPersistence {
-    func createDocumentShare(documentShare: DocumentShare) async -> DocumentShare?
+    func createDocumentShare(documentShare: DocumentShare) async -> Document?
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/DocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/DocumentsPersistence.swift
@@ -8,5 +8,6 @@ protocol DocumentsPersistence {
     func createDocument(document: Document) async -> Document?
     func updateDocument(document: Document) async -> Document?
     func deleteDocument(document: Document) async -> Document?
+    func createOrUpdateDocument(document: Document) -> Document?
     func createOrUpdateDocuments(documents: [Document]) -> [Document]?
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/DocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/DocumentsPersistence.swift
@@ -8,6 +8,6 @@ protocol DocumentsPersistence {
     func createDocument(document: Document) async -> Document?
     func updateDocument(document: Document) async -> Document?
     func deleteDocument(document: Document) async -> Document?
-    func createOrUpdateDocument(document: Document) -> Document?
-    func createOrUpdateDocuments(documents: [Document]) -> [Document]?
+    func createOrUpdateDocument(document: Document) async -> Document?
+    func createOrUpdateDocuments(documents: [Document]) async -> [Document]?
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/LocalPersistenceManager/LocalAnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/LocalPersistenceManager/LocalAnnotationsPersistence.swift
@@ -32,18 +32,18 @@ struct LocalAnnotationsPersistence: AnnotationsPersistence {
         return Annotation.fromManagedEntity(deletedAnnotation)
     }
 
-    func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]? {
-        annotations.compactMap({ annotation in
-            createOrUpdateAnnotation(annotation: annotation)
-        })
-    }
-
-    private func createOrUpdateAnnotation(annotation: Annotation) -> Annotation? {
+    func createOrUpdateAnnotation(annotation: Annotation) -> Annotation? {
         if LocalAnnotationEntityDataAccess.read(annotationId: annotation.id,
                                                 withDeleted: true) != nil {
             return updateAnnotation(annotation: annotation)
         } else {
             return createAnnotation(annotation: annotation)
         }
+    }
+
+    func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]? {
+        annotations.compactMap({ annotation in
+            createOrUpdateAnnotation(annotation: annotation)
+        })
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/LocalPersistenceManager/LocalDocumentSharesPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/LocalPersistenceManager/LocalDocumentSharesPersistence.swift
@@ -1,7 +1,7 @@
 import AnnotatoSharedLibrary
 
 struct LocalDocumentSharesPersistence: DocumentSharesPersistence {
-    func createDocumentShare(documentShare: DocumentShare) -> DocumentShare? {
+    func createDocumentShare(documentShare: DocumentShare) -> Document? {
         fatalError("Should not create DocumentShare in local persistence!")
         return nil
     }

--- a/Annotato/Annotato/Persistence/PersistenceManager/LocalPersistenceManager/LocalDocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/LocalPersistenceManager/LocalDocumentsPersistence.swift
@@ -65,18 +65,18 @@ struct LocalDocumentsPersistence: DocumentsPersistence {
         return Document.fromManagedEntity(deletedDocument)
     }
 
-    func createOrUpdateDocuments(documents: [Document]) -> [Document]? {
-        documents.compactMap({ document in
-            createOrUpdateDocument(document: document)
-        })
-    }
-
-    private func createOrUpdateDocument(document: Document) -> Document? {
+    func createOrUpdateDocument(document: Document) -> Document? {
         if LocalDocumentEntityDataAccess.read(documentId: document.id,
                                               withDeleted: true) != nil {
             return updateDocument(document: document)
         } else {
             return createDocument(document: document)
         }
+    }
+
+    func createOrUpdateDocuments(documents: [Document]) -> [Document]? {
+        documents.compactMap({ document in
+            createOrUpdateDocument(document: document)
+        })
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemoteAnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemoteAnnotationsPersistence.swift
@@ -34,6 +34,11 @@ struct RemoteAnnotationsPersistence: AnnotationsPersistence {
         return nil
     }
 
+    func createOrUpdateAnnotation(annotation: Annotation) -> Annotation? {
+        fatalError("RemoteAnnotationsPersistence::createOrUpdateAnnotation: This function should not be called")
+        return nil
+    }
+
     func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]? {
         fatalError("RemoteAnnotationsPersistence::createOrUpdateAnnotations: This function should not be called")
         return nil

--- a/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemoteDocumentSharesPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemoteDocumentSharesPersistence.swift
@@ -11,7 +11,7 @@ struct RemoteDocumentSharesPersistence: DocumentSharesPersistence {
     }
 
     // MARK: CREATE
-    func createDocumentShare(documentShare: DocumentShare) async -> DocumentShare? {
+    func createDocumentShare(documentShare: DocumentShare) async -> Document? {
         guard let requestData = encodeDocumentShare(documentShare) else {
             AnnotatoLogger.error("DocumentShare was not created",
                                  context: "RemoteDocumentSharesPersistence::createDocumentShare")
@@ -21,7 +21,7 @@ struct RemoteDocumentSharesPersistence: DocumentSharesPersistence {
         do {
             let responseData =
                 try await httpService.post(url: RemoteDocumentSharesPersistence.documentSharesUrl, data: requestData)
-            return try JSONCustomDecoder().decode(DocumentShare.self, from: responseData)
+            return try JSONCustomDecoder().decode(Document.self, from: responseData)
         } catch {
             AnnotatoLogger.error("When creating document share: \(error.localizedDescription)")
             return nil

--- a/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemoteDocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemoteDocumentsPersistence.swift
@@ -96,6 +96,11 @@ struct RemoteDocumentsPersistence: DocumentsPersistence {
         }
     }
 
+    func createOrUpdateDocument(document: Document) -> Document? {
+        fatalError("RemoteDocumentsPersistence::createOrUpdateDocument: This function should not be called")
+        return nil
+    }
+
     func createOrUpdateDocuments(documents: [Document]) -> [Document]? {
         fatalError("RemoteDocumentsPersistence::createOrUpdateDocuments: This function should not be called")
         return nil

--- a/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemotePersistenceManager.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemotePersistenceManager.swift
@@ -1,5 +1,5 @@
 struct RemotePersistenceManager {
-    private static let shouldUseLocalEndpoint = true
+    private static let shouldUseLocalEndpoint = false
 
     // HTTP
     private static let localApiEndpoint = "http://127.0.0.1:8080"

--- a/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemotePersistenceManager.swift
+++ b/Annotato/Annotato/Persistence/PersistenceManager/RemotePersistenceManager/RemotePersistenceManager.swift
@@ -1,5 +1,5 @@
 struct RemotePersistenceManager {
-    private static let shouldUseLocalEndpoint = false
+    private static let shouldUseLocalEndpoint = true
 
     // HTTP
     private static let localApiEndpoint = "http://127.0.0.1:8080"

--- a/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+AnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+AnnotationsPersistence.swift
@@ -17,6 +17,10 @@ extension OfflinePersistenceService: AnnotationsPersistence {
         return await localPersistence.annotations.deleteAnnotation(annotation: annotation)
     }
 
+    func createOrUpdateAnnotation(annotation: Annotation) -> Annotation? {
+        localPersistence.annotations.createOrUpdateAnnotation(annotation: annotation)
+    }
+
     func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]? {
         localPersistence.annotations.createOrUpdateAnnotations(annotations: annotations)
     }

--- a/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+AnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+AnnotationsPersistence.swift
@@ -17,11 +17,23 @@ extension OfflinePersistenceService: AnnotationsPersistence {
         return await localPersistence.annotations.deleteAnnotation(annotation: annotation)
     }
 
-    func createOrUpdateAnnotation(annotation: Annotation) -> Annotation? {
-        localPersistence.annotations.createOrUpdateAnnotation(annotation: annotation)
+    func createOrUpdateAnnotation(annotation: Annotation) async -> Annotation? {
+        if LocalAnnotationEntityDataAccess.read(annotationId: annotation.id,
+                                                withDeleted: true) != nil {
+            return await self.updateAnnotation(annotation: annotation)
+        } else {
+            return await self.createAnnotation(annotation: annotation)
+        }
     }
 
-    func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]? {
-        localPersistence.annotations.createOrUpdateAnnotations(annotations: annotations)
+    func createOrUpdateAnnotations(annotations: [Annotation]) async -> [Annotation]? {
+        var annotations: [Annotation] = []
+        for annotation in annotations {
+            guard let annotationToAppend = await self.createOrUpdateAnnotation(annotation: annotation) else {
+                return nil
+            }
+            annotations.append(annotationToAppend)
+        }
+        return annotations
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+DocumentSharesPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+DocumentSharesPersistence.swift
@@ -2,7 +2,7 @@ import AnnotatoSharedLibrary
 import Foundation
 
 extension OfflinePersistenceService: DocumentSharesPersistence {
-    func createDocumentShare(documentShare: DocumentShare) async -> DocumentShare? {
+    func createDocumentShare(documentShare: DocumentShare) async -> Document? {
         await localPersistence.documentShares.createDocumentShare(documentShare: documentShare)
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+DocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+DocumentsPersistence.swift
@@ -29,11 +29,23 @@ extension OfflinePersistenceService: DocumentsPersistence {
         return await localPersistence.documents.deleteDocument(document: document)
     }
 
-    func createOrUpdateDocument(document: Document) -> Document? {
-        localPersistence.documents.createOrUpdateDocument(document: document)
+    func createOrUpdateDocument(document: Document) async -> Document? {
+        if LocalDocumentEntityDataAccess.read(documentId: document.id,
+                                              withDeleted: true) != nil {
+            return await updateDocument(document: document)
+        } else {
+            return await createDocument(document: document)
+        }
     }
 
-    func createOrUpdateDocuments(documents: [Document]) -> [Document]? {
-        localPersistence.documents.createOrUpdateDocuments(documents: documents)
+    func createOrUpdateDocuments(documents: [Document]) async -> [Document]? {
+        var documents: [Document] = []
+        for document in documents {
+            guard let documentToAppend = await self.createOrUpdateDocument(document: document) else {
+                return nil
+            }
+            documents.append(documentToAppend)
+        }
+        return documents
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+DocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OfflinePersistenceService/OfflinePersistenceService+DocumentsPersistence.swift
@@ -29,6 +29,10 @@ extension OfflinePersistenceService: DocumentsPersistence {
         return await localPersistence.documents.deleteDocument(document: document)
     }
 
+    func createOrUpdateDocument(document: Document) -> Document? {
+        localPersistence.documents.createOrUpdateDocument(document: document)
+    }
+
     func createOrUpdateDocuments(documents: [Document]) -> [Document]? {
         localPersistence.documents.createOrUpdateDocuments(documents: documents)
     }

--- a/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+AnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+AnnotationsPersistence.swift
@@ -3,22 +3,54 @@ import Foundation
 
 extension OnlinePersistenceService: AnnotationsPersistence {
     func createAnnotation(annotation: Annotation) async -> Annotation? {
-        await remotePersistence.annotations.createAnnotation(annotation: annotation)
+        guard let createdAnnotationRemote = await remotePersistence
+            .annotations
+            .createAnnotation(annotation: annotation) else {
+            return nil
+        }
+        guard let createdAnnotationLocal = await localPersistence
+            .annotations
+            .createAnnotation(annotation: createdAnnotationRemote) else {
+            return nil
+        }
+        return createdAnnotationLocal
     }
 
     func updateAnnotation(annotation: Annotation) async -> Annotation? {
-        await remotePersistence.annotations.updateAnnotation(annotation: annotation)
+        guard let updatedAnnotationRemote = await remotePersistence
+            .annotations
+            .updateAnnotation(annotation: annotation) else {
+            return nil
+        }
+        guard let updatedAnnotationLocal = await localPersistence
+            .annotations
+            .updateAnnotation(annotation: updatedAnnotationRemote) else {
+            return nil
+        }
+        return updatedAnnotationLocal
     }
 
     func deleteAnnotation(annotation: Annotation) async -> Annotation? {
-        await remotePersistence.annotations.deleteAnnotation(annotation: annotation)
+        guard let deletedAnnotationRemote = await remotePersistence
+            .annotations
+            .deleteAnnotation(annotation: annotation) else {
+            return nil
+        }
+        guard let deletedAnnotationLocal = await localPersistence
+            .annotations
+            .deleteAnnotation(annotation: deletedAnnotationRemote) else {
+            return nil
+        }
+        return deletedAnnotationLocal
     }
 
     func createOrUpdateAnnotation(annotation: Annotation) -> Annotation? {
-        localPersistence.annotations.createOrUpdateAnnotation(annotation: annotation)
+        fatalError("OnlinePersistenceService::createOrUpdateAnnotation: This function should not be called")
+        return nil
     }
 
     func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]? {
-        localPersistence.annotations.createOrUpdateAnnotations(annotations: annotations)
+        fatalError("OnlinePersistenceService::createOrUpdateAnnotations: This function should not be called")
+        return nil
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+AnnotationsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+AnnotationsPersistence.swift
@@ -14,6 +14,10 @@ extension OnlinePersistenceService: AnnotationsPersistence {
         await remotePersistence.annotations.deleteAnnotation(annotation: annotation)
     }
 
+    func createOrUpdateAnnotation(annotation: Annotation) -> Annotation? {
+        localPersistence.annotations.createOrUpdateAnnotation(annotation: annotation)
+    }
+
     func createOrUpdateAnnotations(annotations: [Annotation]) -> [Annotation]? {
         localPersistence.annotations.createOrUpdateAnnotations(annotations: annotations)
     }

--- a/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentSharesPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentSharesPersistence.swift
@@ -2,12 +2,14 @@ import AnnotatoSharedLibrary
 import Foundation
 
 extension OnlinePersistenceService: DocumentSharesPersistence {
-    func createDocumentShare(documentShare: DocumentShare) async -> DocumentShare? {
-        guard let createdDocumentShareRemote = await remotePersistence
+    func createDocumentShare(documentShare: DocumentShare) async -> Document? {
+        guard let sharedDocument = await remotePersistence
             .documentShares
             .createDocumentShare(documentShare: documentShare) else {
             return nil
         }
-        return createdDocumentShareRemote
+
+        _ = await localPersistence.documents.createDocument(document: sharedDocument)
+        return sharedDocument
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentSharesPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentSharesPersistence.swift
@@ -3,13 +3,13 @@ import Foundation
 
 extension OnlinePersistenceService: DocumentSharesPersistence {
     func createDocumentShare(documentShare: DocumentShare) async -> Document? {
-        guard let sharedDocument = await remotePersistence
+        guard let sharedDocumentRemote = await remotePersistence
             .documentShares
             .createDocumentShare(documentShare: documentShare) else {
             return nil
         }
 
-        _ = await localPersistence.documents.createDocument(document: sharedDocument)
-        return sharedDocument
+        let sharedDocumentLocal = await localPersistence.documents.createDocument(document: sharedDocumentRemote)
+        return sharedDocumentLocal
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentsPersistence.swift
@@ -53,10 +53,12 @@ extension OnlinePersistenceService: DocumentsPersistence {
     }
 
     func createOrUpdateDocument(document: Document) -> Document? {
-        localPersistence.documents.createOrUpdateDocument(document: document)
+        fatalError("OnlinePersistenceService::createOrUpdateDocument: This function should not be called")
+        return nil
     }
 
     func createOrUpdateDocuments(documents: [Document]) -> [Document]? {
-        localPersistence.documents.createOrUpdateDocuments(documents: documents)
+        fatalError("OnlinePersistenceService::createOrUpdateDocuments: This function should not be called")
+        return nil
     }
 }

--- a/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentsPersistence.swift
+++ b/Annotato/Annotato/Persistence/PersistenceService/OnlinePersistenceService/OnlinePersistenceService+DocumentsPersistence.swift
@@ -52,6 +52,10 @@ extension OnlinePersistenceService: DocumentsPersistence {
         return deletedDocumentLocal
     }
 
+    func createOrUpdateDocument(document: Document) -> Document? {
+        localPersistence.documents.createOrUpdateDocument(document: document)
+    }
+
     func createOrUpdateDocuments(documents: [Document]) -> [Document]? {
         localPersistence.documents.createOrUpdateDocuments(documents: documents)
     }

--- a/Annotato/Annotato/Utils/NetworkMonitor.swift
+++ b/Annotato/Annotato/Utils/NetworkMonitor.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import Combine
 
-class NetworkMonitor {
+class NetworkMonitor: ObservableObject {
     static let shared = NetworkMonitor()
 
     @Published private(set) var isConnected = false

--- a/Annotato/Annotato/Utils/NetworkMonitor.swift
+++ b/Annotato/Annotato/Utils/NetworkMonitor.swift
@@ -1,10 +1,11 @@
 import Foundation
 import Network
+import Combine
 
 class NetworkMonitor {
     static let shared = NetworkMonitor()
 
-    private(set) var isConnected = false
+    @Published private(set) var isConnected = false
     private let queue = DispatchQueue.global()
     private let monitor = NWPathMonitor()
 

--- a/Annotato/Annotato/WebSocket/AnnotationWebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/AnnotationWebSocketManager.swift
@@ -35,7 +35,10 @@ class AnnotationWebSocketManager: ObservableObject {
                 AnnotatoLogger.info("Annotation was deleted. \(annotation)")
             }
 
-            _ = LocalPersistenceManager.shared.annotations.createOrUpdateAnnotation(annotation: annotation)
+            Task {
+                _ = await LocalPersistenceManager.shared.annotations
+                    .createOrUpdateAnnotation(annotation: annotation)
+            }
         } catch {
             AnnotatoLogger.error(
                 "When handling response data. \(error.localizedDescription).",

--- a/Annotato/Annotato/WebSocket/AnnotationWebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/AnnotationWebSocketManager.swift
@@ -35,6 +35,7 @@ class AnnotationWebSocketManager: ObservableObject {
                 AnnotatoLogger.info("Annotation was deleted. \(annotation)")
             }
 
+            _ = LocalPersistenceManager.shared.annotations.createOrUpdateAnnotation(annotation: annotation)
         } catch {
             AnnotatoLogger.error(
                 "When handling response data. \(error.localizedDescription).",

--- a/Annotato/Annotato/WebSocket/DocumentWebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/DocumentWebSocketManager.swift
@@ -35,6 +35,7 @@ class DocumentWebSocketManager: ObservableObject {
                 AnnotatoLogger.info("Document was deleted. \(document)")
             }
 
+            _ = LocalPersistenceManager.shared.documents.createOrUpdateDocument(document: document)
         } catch {
             AnnotatoLogger.error(
                 "When handling response data. \(error.localizedDescription).",

--- a/Annotato/Annotato/WebSocket/DocumentWebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/DocumentWebSocketManager.swift
@@ -35,7 +35,10 @@ class DocumentWebSocketManager: ObservableObject {
                 AnnotatoLogger.info("Document was deleted. \(document)")
             }
 
-            _ = LocalPersistenceManager.shared.documents.createOrUpdateDocument(document: document)
+            Task {
+                _ = await LocalPersistenceManager.shared.documents
+                    .createOrUpdateDocument(document: document)
+            }
         } catch {
             AnnotatoLogger.error(
                 "When handling response data. \(error.localizedDescription).",

--- a/Annotato/Annotato/WebSocket/OfflineToOnlineWebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/OfflineToOnlineWebSocketManager.swift
@@ -11,7 +11,6 @@ class OfflineToOnlineWebSocketManager {
             let annotations = message.annotations
 
             _ = LocalPersistenceManager.shared.documents.createOrUpdateDocuments(documents: documents)
-
             _ = LocalPersistenceManager.shared.annotations.createOrUpdateAnnotations(annotations: annotations)
         } catch {
             AnnotatoLogger.error("When handling response data. \(error.localizedDescription)",

--- a/Annotato/Annotato/WebSocket/OfflineToOnlineWebSocketManager.swift
+++ b/Annotato/Annotato/WebSocket/OfflineToOnlineWebSocketManager.swift
@@ -10,8 +10,12 @@ class OfflineToOnlineWebSocketManager {
             let documents = message.documents
             let annotations = message.annotations
 
-            _ = LocalPersistenceManager.shared.documents.createOrUpdateDocuments(documents: documents)
-            _ = LocalPersistenceManager.shared.annotations.createOrUpdateAnnotations(annotations: annotations)
+            Task {
+                _ = await LocalPersistenceManager.shared.documents
+                    .createOrUpdateDocuments(documents: documents)
+                _ = await LocalPersistenceManager.shared.annotations
+                    .createOrUpdateAnnotations(annotations: annotations)
+            }
         } catch {
             AnnotatoLogger.error("When handling response data. \(error.localizedDescription)",
                                  context: "OfflineToOnlineWebSocketManager::handleResponseData")

--- a/AnnotatoBackend/Sources/App/Controllers/DocumentSharesController.swift
+++ b/AnnotatoBackend/Sources/App/Controllers/DocumentSharesController.swift
@@ -3,9 +3,10 @@ import Vapor
 import AnnotatoSharedLibrary
 
 struct DocumentSharesController {
-    static func create(req: Request) async throws -> DocumentShare {
+    static func create(req: Request) async throws -> Document {
         let documentShare = try req.content.decode(DocumentShare.self, using: JSONCustomDecoder())
 
-        return try await DocumentSharesDataAccess.create(db: req.db, documentShare: documentShare)
+        _ = try await DocumentSharesDataAccess.create(db: req.db, documentShare: documentShare)
+        return try await DocumentsDataAccess.read(db: req.db, documentId: documentShare.documentId)
     }
 }


### PR DESCRIPTION
Changes
- Persist websocket responses locally
- Persist shared document locally
- Disable import from code when offline (P.S. `isConnected` doesn't seem to be working properly :<)