### PR TITLE
Allow Conflict resolver methods to be overridden

### DIFF
--- a/Annotato/Annotato/ConflictResolution/ConflictResolver.swift
+++ b/Annotato/Annotato/ConflictResolution/ConflictResolver.swift
@@ -24,7 +24,7 @@ class ConflictResolver<Model: ConflictResolvable> {
     var serverModelsMap: [Model.ID: Model] {
         Dictionary(uniqueKeysWithValues: serverModels.map({ ($0.id, $0) }))
     }
-    
+
     func resolve() -> ConflictResolution<Model> {
         var resolution = ConflictResolution<Model>()
         for localId in localIds where !serverIds.contains(localId) {
@@ -43,15 +43,19 @@ class ConflictResolver<Model: ConflictResolvable> {
     }
 
     func handleExclusiveToLocal(localModelId: Model.ID, resolution: inout ConflictResolution<Model>) {
-        let localModel = localModelsMap[localModelId]
-        resolution.serverCreate.appendIfNotNil(localModel)
-        resolution.nonConflictingModels.appendIfNotNil(localModel)
+        guard let localModel = localModelsMap[localModelId] else {
+            return
+        }
+        resolution.serverCreate.append(localModel)
+        resolution.nonConflictingModels.append(localModel)
     }
 
     func handleExclusiveToServer(serverModelId: Model.ID, resolution: inout ConflictResolution<Model>) {
-        let serverModel = serverModelsMap[serverModelId]
-        resolution.localCreate.appendIfNotNil(serverModel)
-        resolution.nonConflictingModels.appendIfNotNil(serverModel)
+        guard let serverModel = serverModelsMap[serverModelId] else {
+            return
+        }
+        resolution.localCreate.append(serverModel)
+        resolution.nonConflictingModels.append(serverModel)
     }
 
     func handleCommonToLocalAndServer(commonModelId: Model.ID, resolution: inout ConflictResolution<Model>) {

--- a/Annotato/Annotato/ConflictResolution/ConflictResolver.swift
+++ b/Annotato/Annotato/ConflictResolution/ConflictResolver.swift
@@ -9,6 +9,22 @@ class ConflictResolver<Model: ConflictResolvable> {
         self.serverModels = serverModels
     }
 
+    private var localIds: Set<Model.ID> {
+        Set(localModels.map({ $0.id }))
+    }
+
+    private var serverIds: Set<Model.ID> {
+        Set(serverModels.map({ $0.id }))
+    }
+
+    var localModelsMap: [Model.ID: Model] {
+        Dictionary(uniqueKeysWithValues: localModels.map({ ($0.id, $0) }))
+    }
+
+    var serverModelsMap: [Model.ID: Model] {
+        Dictionary(uniqueKeysWithValues: serverModels.map({ ($0.id, $0) }))
+    }
+    
     func resolve() -> ConflictResolution<Model> {
         var resolution = ConflictResolution<Model>()
         for localId in localIds where !serverIds.contains(localId) {
@@ -26,23 +42,7 @@ class ConflictResolver<Model: ConflictResolvable> {
         return resolution
     }
 
-    private var localIds: Set<Model.ID> {
-        Set(localModels.map({ $0.id }))
-    }
-
-    private var serverIds: Set<Model.ID> {
-        Set(serverModels.map({ $0.id }))
-    }
-
-    var localModelsMap: [Model.ID: Model] {
-        Dictionary(uniqueKeysWithValues: localModels.map({ ($0.id, $0) }))
-    }
-
-    var serverModelsMap: [Model.ID: Model] {
-        Dictionary(uniqueKeysWithValues: serverModels.map({ ($0.id, $0) }))
-    }
-
-    private func handleExclusiveToLocal(localModelId: Model.ID, resolution: inout ConflictResolution<Model>) {
+    func handleExclusiveToLocal(localModelId: Model.ID, resolution: inout ConflictResolution<Model>) {
         let localModel = localModelsMap[localModelId]
         resolution.serverCreate.appendIfNotNil(localModel)
         resolution.nonConflictingModels.appendIfNotNil(localModel)

--- a/Annotato/Annotato/ConflictResolution/Document+ConflictResolvable.swift
+++ b/Annotato/Annotato/ConflictResolution/Document+ConflictResolvable.swift
@@ -1,0 +1,5 @@
+import AnnotatoSharedLibrary
+
+extension Document: ConflictResolvable {
+
+}

--- a/Annotato/Annotato/ConflictResolution/DocumentConflictResolver.swift
+++ b/Annotato/Annotato/ConflictResolution/DocumentConflictResolver.swift
@@ -1,0 +1,9 @@
+import AnnotatoSharedLibrary
+
+class DocumentConflictResolver: ConflictResolver<Document> {
+    override func handleExclusiveToServer(serverModelId: Document.ID, resolution: inout ConflictResolution<Document>) {
+        let serverModel = serverModelsMap[serverModelId]
+        resolution.serverDelete.appendIfNotNil(serverModel)
+        resolution.nonConflictingModels.appendIfNotNil(serverModel)
+    }
+}

--- a/Annotato/Annotato/ConflictResolution/DocumentConflictResolver.swift
+++ b/Annotato/Annotato/ConflictResolution/DocumentConflictResolver.swift
@@ -2,8 +2,10 @@ import AnnotatoSharedLibrary
 
 class DocumentConflictResolver: ConflictResolver<Document> {
     override func handleExclusiveToServer(serverModelId: Document.ID, resolution: inout ConflictResolution<Document>) {
-        let serverModel = serverModelsMap[serverModelId]
-        resolution.serverDelete.appendIfNotNil(serverModel)
-        resolution.nonConflictingModels.appendIfNotNil(serverModel)
+        guard let serverModel = serverModelsMap[serverModelId] else {
+            return
+        }
+        resolution.serverDelete.append(serverModel)
+        resolution.nonConflictingModels.append(serverModel)
     }
 }

--- a/Annotato/Annotato/ConflictResolution/DocumentConflictResolver.swift
+++ b/Annotato/Annotato/ConflictResolution/DocumentConflictResolver.swift
@@ -1,10 +1,7 @@
 import AnnotatoSharedLibrary
 
 class DocumentConflictResolver: ConflictResolver<Document> {
-    override func handleExclusiveToServer(serverModelId: Document.ID, resolution: inout ConflictResolution<Document>) {
-        guard let serverModel = serverModelsMap[serverModelId] else {
-            return
-        }
+    override func handleExclusiveToServer(serverModel: Document, resolution: inout ConflictResolution<Document>) {
         resolution.serverDelete.append(serverModel)
         resolution.nonConflictingModels.append(serverModel)
     }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Extensions/Array+AppendIfNotNil.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Extensions/Array+AppendIfNotNil.swift
@@ -1,7 +1,0 @@
-extension Array {
-    public mutating func appendIfNotNil(_ newElement: Element?) {
-        if let element = newElement {
-            self.append(element)
-        }
-    }
-}


### PR DESCRIPTION
Changes
- Changed `ConflictResolver` to be a class to allow inheritance 
- Add DocumentResolver with one overridden method `handleExclusiveToServer`

@zognin Feel free to make any changes and merge if needed