### PR TITLE
Fix dependency on storage implementation

### DIFF
--- a/Annotato/Annotato/Adapters/AnnotatoLocalStorageService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoLocalStorageService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AnnotatoSharedLibrary
 
 protocol AnnotatoLocalStorageService {
     func getUrl(fileName: String) -> URL

--- a/Annotato/Annotato/Adapters/AnnotatoLocalStorageService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoLocalStorageService.swift
@@ -1,8 +1,9 @@
 import Foundation
 import AnnotatoSharedLibrary
 
-protocol AnnotatoStorageService {
-    func getDownloadUrl(fileName: String) async -> URL?
+protocol AnnotatoLocalStorageService {
+    func getUrl(fileName: String) -> URL
     func uploadPdf(fileSystemUrl: URL, fileName: String)
+    func uploadPdf(pdfData: Data, fileName: String)
     func deletePdf(fileName: String)
 }

--- a/Annotato/Annotato/Adapters/AnnotatoRemoteStorageService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoRemoteStorageService.swift
@@ -1,0 +1,8 @@
+import Foundation
+import AnnotatoSharedLibrary
+
+protocol AnnotatoRemoteStorageService {
+    func getDownloadUrl(fileName: String) async -> URL?
+    func uploadPdf(fileSystemUrl: URL, fileName: String)
+    func deletePdf(fileName: String)
+}

--- a/Annotato/Annotato/Adapters/AnnotatoRemoteStorageService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoRemoteStorageService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AnnotatoSharedLibrary
 
 protocol AnnotatoRemoteStorageService {
     func getDownloadUrl(fileName: String) async -> URL?

--- a/Annotato/Annotato/Adapters/AnnotatoStorageService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoStorageService.swift
@@ -2,6 +2,8 @@ import Foundation
 import AnnotatoSharedLibrary
 
 protocol AnnotatoStorageService {
+    func getUrl(fileName: String)
     func uploadPdf(fileSystemUrl: URL, fileName: String)
+    func uploadPdf(pdfData: Data, fileName: String)
     func deletePdf(fileName: String)
 }

--- a/Annotato/Annotato/Adapters/AnnotatoStorageService.swift
+++ b/Annotato/Annotato/Adapters/AnnotatoStorageService.swift
@@ -2,8 +2,7 @@ import Foundation
 import AnnotatoSharedLibrary
 
 protocol AnnotatoStorageService {
-    func getUrl(fileName: String)
+    func getDownloadUrl(fileName: String) async -> URL?
     func uploadPdf(fileSystemUrl: URL, fileName: String)
-    func uploadPdf(pdfData: Data, fileName: String)
     func deletePdf(fileName: String)
 }

--- a/Annotato/Annotato/Interactors/DocumentSharesInteractor.swift
+++ b/Annotato/Annotato/Interactors/DocumentSharesInteractor.swift
@@ -11,11 +11,7 @@ class DocumentSharesInteractor {
             return nil
         }
 
-        let wasDocumentCopied = await PDFStorageManager()
-            .downloadPdfToLocalStorage(fileName: remoteDocument.id.uuidString)
-        guard wasDocumentCopied else {
-            return nil
-        }
+        await PDFStorageManager().downloadPdfToLocalStorage(fileName: remoteDocument.id.uuidString)
 
         let localSharedDocument = localDocumentsPersistence.createDocument(document: remoteDocument)
         return localSharedDocument

--- a/Annotato/Annotato/Interactors/DocumentSharesInteractor.swift
+++ b/Annotato/Annotato/Interactors/DocumentSharesInteractor.swift
@@ -11,7 +11,8 @@ class DocumentSharesInteractor {
             return nil
         }
 
-        let wasDocumentCopied = await copyDocumentPDFToLocalStorage(document: remoteDocument)
+        let wasDocumentCopied = await PDFStorageManager()
+            .downloadPdfToLocalStorage(fileName: remoteDocument.id.uuidString)
         guard wasDocumentCopied else {
             return nil
         }
@@ -26,28 +27,5 @@ class DocumentSharesInteractor {
 
         // Note: Documents are permanently deleted locally
         return localDocumentsPersistence.deleteDocument(document: remoteDeletedDocument ?? document)
-    }
-
-    private func copyDocumentPDFToLocalStorage(document: Document) async -> Bool {
-        guard let downloadURL = await FirebaseStorage().getDownloadURL(documentId: document.id) else {
-            AnnotatoLogger.error("Could not get download URL for document",
-                                 context: "PersistenceManager::copyDocumentPDFToLocalStorage")
-            return false
-        }
-
-        guard let documentPDFData = try? await URLSessionHTTPService().get(url: downloadURL.absoluteString) else {
-            AnnotatoLogger.error("Could not retrieve document PDF data using HTTP",
-                                 context: "PersistenceManager::copyDocumentPDFToLocalStorage")
-            return false
-        }
-
-        let wasPDFSavedLocally = LocalStorage().uploadPdf(pdfData: documentPDFData, fileName: document.id.uuidString)
-        guard wasPDFSavedLocally else {
-            AnnotatoLogger.error("Could not save document PDF to local file system",
-                                 context: "PersistenceManager::copyDocumentPDFToLocalStorage")
-            return false
-        }
-
-        return true
     }
 }

--- a/Annotato/Annotato/Presenters/Document/PdfPresenter.swift
+++ b/Annotato/Annotato/Presenters/Document/PdfPresenter.swift
@@ -6,7 +6,8 @@ class PdfPresenter {
     let document: PDFDocument
 
     init(document: Document) {
-        guard let pdfDocument = PDFDocument(url: document.localFileUrl) else {
+        guard let pdfDocument = PDFDocument(url: PDFStorageManager()
+            .getLocalUrl(fileName: document.id.uuidString)) else {
             AnnotatoLogger.error("Could not load document")
             // TODO: Handle failed init more gracefully
             fatalError("No such document")

--- a/Annotato/Annotato/Storage/PDFStorageManager.swift
+++ b/Annotato/Annotato/Storage/PDFStorageManager.swift
@@ -2,10 +2,11 @@ import Foundation
 import AnnotatoSharedLibrary
 
 class PDFStorageManager {
-    private var localStorageService = LocalStorage()
-    private var remoteStorageService: AnnotatoStorageService
+    private var localStorageService: AnnotatoLocalStorageService
+    private var remoteStorageService: AnnotatoRemoteStorageService
 
     init() {
+        localStorageService = LocalStorage()
         remoteStorageService = FirebaseStorage()
     }
 

--- a/Annotato/Annotato/Storage/PDFStorageManager.swift
+++ b/Annotato/Annotato/Storage/PDFStorageManager.swift
@@ -16,6 +16,29 @@ class PDFStorageManager {
         remoteStorageService.uploadPdf(fileSystemUrl: fileSystemUrl, fileName: fileName)
     }
 
+    func downloadPdfToLocalStorage(fileName: String) async -> Bool {
+        guard let downloadURL = await remoteStorageService.getUrl(fileName: fileName) else {
+            AnnotatoLogger.error("Could not get download URL for document",
+                                 context: "PDFStorageManager::downloadPdfToLocalStorage")
+            return false
+        }
+
+        guard let documentPDFData = try? await URLSessionHTTPService().get(url: downloadURL.absoluteString) else {
+            AnnotatoLogger.error("Could not retrieve document PDF data using HTTP",
+                                 context: "PDFStorageManager::downloadPdfToLocalStorage")
+            return false
+        }
+
+        let wasPDFSavedLocally = localStorageService.uploadPdf(pdfData: documentPDFData, fileName: document.id.uuidString)
+        guard wasPDFSavedLocally else {
+            AnnotatoLogger.error("Could not save document PDF to local file system",
+                                 context: "PDFStorageManager::downloadPdfToLocalStorage")
+            return false
+        }
+
+        return true
+    }
+
     func deletePdf(fileName: String) {
         localStorageService.deletePdf(fileName: fileName)
 

--- a/Annotato/Annotato/Storage/PDFStorageManager.swift
+++ b/Annotato/Annotato/Storage/PDFStorageManager.swift
@@ -20,7 +20,7 @@ class PDFStorageManager {
     }
 
     func downloadPdfToLocalStorage(fileName: String) async {
-        guard let downloadURL = await remoteStorageService.getUrl(fileName: fileName) else {
+        guard let downloadURL = await remoteStorageService.getDownloadUrl(fileName: fileName) else {
             AnnotatoLogger.error("Could not get download URL for document",
                                  context: "PDFStorageManager::downloadPdfToLocalStorage")
             return
@@ -32,7 +32,7 @@ class PDFStorageManager {
             return
         }
 
-        localStorageService.uploadPdf(pdfData: documentPDFData, fileName: document.id.uuidString)
+        localStorageService.uploadPdf(pdfData: documentPDFData, fileName: fileName)
     }
 
     func deletePdf(fileName: String) {

--- a/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
@@ -1,6 +1,5 @@
 import Firebase
 import FirebaseStorage
-import AnnotatoSharedLibrary
 
 class FirebaseStorage: AnnotatoRemoteStorageService {
     private let storage = Storage.storage()

--- a/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
@@ -2,7 +2,7 @@ import Firebase
 import FirebaseStorage
 import AnnotatoSharedLibrary
 
-class FirebaseStorage: AnnotatoStorageService {
+class FirebaseStorage: AnnotatoRemoteStorageService {
     private let storage = Storage.storage()
     private var storageRef: StorageReference {
         storage.reference()

--- a/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
@@ -8,7 +8,7 @@ class FirebaseStorage: AnnotatoStorageService {
         storage.reference()
     }
 
-    func getUrl(fileName: String) async -> URL? {
+    func getDownloadUrl(fileName: String) async -> URL? {
         let pdfRef = storageRef.child(documentId.uuidString)
         do {
             return try await pdfRef.downloadURL()
@@ -32,22 +32,6 @@ class FirebaseStorage: AnnotatoStorageService {
             }
 
             AnnotatoLogger.info("Uploaded to Firebase - PDF with fileSystemUrl: \(fileSystemUrl)")
-        }
-    }
-
-    func uploadPdf(pdfData: Data, fileName: String) {
-        let pdfRef = storageRef.child(fileName)
-
-        _ = pdfRef.putData(pdfData, metadata: nil) { _, error in
-            if let error = error {
-                AnnotatoLogger.error(
-                    "When uploading PDF data to FB. \(error.localizedDescription)",
-                    context: "FirebaseStorage::uploadPdf"
-                )
-                return
-            }
-
-            AnnotatoLogger.info("Uploaded to Firebase - PDF data with fileName: \(fileName)")
         }
     }
 

--- a/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
@@ -8,6 +8,17 @@ class FirebaseStorage: AnnotatoStorageService {
         storage.reference()
     }
 
+    func getUrl(fileName: String) async -> URL? {
+        let pdfRef = storageRef.child(documentId.uuidString)
+        do {
+            return try await pdfRef.downloadURL()
+        } catch {
+            AnnotatoLogger.error("Could not get download URL for file \(fileName)",
+                                 context: "FirebaseStorage::getUrl")
+            return nil
+        }
+    }
+
     func uploadPdf(fileSystemUrl: URL, fileName: String) {
         let pdfRef = storageRef.child(fileName)
 
@@ -24,6 +35,22 @@ class FirebaseStorage: AnnotatoStorageService {
         }
     }
 
+    func uploadPdf(pdfData: Data, fileName: String) {
+        let pdfRef = storageRef.child(fileName)
+
+        _ = pdfRef.putData(pdfData, metadata: nil) { _, error in
+            if let error = error {
+                AnnotatoLogger.error(
+                    "When uploading PDF data to FB. \(error.localizedDescription)",
+                    context: "FirebaseStorage::uploadPdf"
+                )
+                return
+            }
+
+            AnnotatoLogger.info("Uploaded to Firebase - PDF data with fileName: \(fileName)")
+        }
+    }
+
     func deletePdf(fileName: String) {
         let pdfRef = storageRef.child(fileName)
         pdfRef.delete { error in
@@ -36,17 +63,6 @@ class FirebaseStorage: AnnotatoStorageService {
             }
 
             AnnotatoLogger.info("Deleted PDF: \(fileName) from FB.")
-        }
-    }
-
-    func getDownloadURL(documentId: UUID) async -> URL? {
-        let pdfRef = storageRef.child(documentId.uuidString)
-        do {
-            return try await pdfRef.downloadURL()
-        } catch {
-            AnnotatoLogger.error("Could not get download URL for document with ID \(documentId)",
-                                 context: "FirebaseStorage::getDownloadURL")
-            return nil
         }
     }
 }

--- a/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/FirebaseStorage.swift
@@ -9,7 +9,7 @@ class FirebaseStorage: AnnotatoStorageService {
     }
 
     func getDownloadUrl(fileName: String) async -> URL? {
-        let pdfRef = storageRef.child(documentId.uuidString)
+        let pdfRef = storageRef.child(fileName)
         do {
             return try await pdfRef.downloadURL()
         } catch {

--- a/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AnnotatoSharedLibrary
 
 class LocalStorage: AnnotatoLocalStorageService {
     var appDocumentsDirectory: URL {

--- a/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
@@ -23,11 +23,10 @@ class LocalStorage: AnnotatoStorageService {
         }
     }
 
-    /// Returns whether the PDF data was successfully written to the documents directory.
-    func uploadPdf(pdfData: Data, fileName: String) -> Bool {
+    func uploadPdf(pdfData: Data, fileName: String) {
         let urlInDocumentsDirectory = getUrl(fileName: fileName)
 
-        return FileManager.default.createFile(atPath: urlInDocumentsDirectory.path, contents: pdfData)
+       FileManager.default.createFile(atPath: urlInDocumentsDirectory.path, contents: pdfData)
     }
 
     func deletePdf(fileName: String) {

--- a/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AnnotatoSharedLibrary
 
-class LocalStorage {
+class LocalStorage: AnnotatoLocalStorageService {
     var appDocumentsDirectory: URL {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }

--- a/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AnnotatoSharedLibrary
 
-class LocalStorage: AnnotatoStorageService {
+class LocalStorage {
     var appDocumentsDirectory: URL {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }

--- a/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
+++ b/Annotato/Annotato/Storage/StorageService/LocalStorage.swift
@@ -6,11 +6,13 @@ class LocalStorage: AnnotatoStorageService {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }
 
+    func getUrl(fileName: String) -> URL {
+        appDocumentsDirectory.appendingPathComponent(fileName).appendingPathExtension(for: .pdf)
+    }
+
     func uploadPdf(fileSystemUrl: URL, fileName: String) {
         do {
-            let urlInDocumentsDirectory = appDocumentsDirectory
-                .appendingPathComponent(fileName)
-                .appendingPathExtension(for: .pdf)
+            let urlInDocumentsDirectory = getUrl(fileName: fileName)
 
             try FileManager.default.copyItem(at: fileSystemUrl, to: urlInDocumentsDirectory)
 
@@ -23,14 +25,14 @@ class LocalStorage: AnnotatoStorageService {
 
     /// Returns whether the PDF data was successfully written to the documents directory.
     func uploadPdf(pdfData: Data, fileName: String) -> Bool {
-        let urlInDocumentsDirectory = getUrlInDocumentsDirectory(fileName: fileName)
+        let urlInDocumentsDirectory = getUrl(fileName: fileName)
 
         return FileManager.default.createFile(atPath: urlInDocumentsDirectory.path, contents: pdfData)
     }
 
     func deletePdf(fileName: String) {
         do {
-            let urlInDocumentsDirectory = getUrlInDocumentsDirectory(fileName: fileName)
+            let urlInDocumentsDirectory = getUrl(fileName: fileName)
 
             try FileManager.default.removeItem(at: urlInDocumentsDirectory)
 
@@ -39,11 +41,5 @@ class LocalStorage: AnnotatoStorageService {
             AnnotatoLogger.error("When trying to delete PDF. \(error.localizedDescription)",
                                  context: "LocalStorage::deletePdf")
         }
-    }
-
-    private func getUrlInDocumentsDirectory(fileName: String) -> URL {
-        appDocumentsDirectory
-            .appendingPathComponent(fileName)
-            .appendingPathExtension(for: .pdf)
     }
 }

--- a/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Document.swift
+++ b/AnnotatoSharedLibrary/Sources/AnnotatoSharedLibrary/Models/Document.swift
@@ -81,13 +81,6 @@ extension Document {
     }
 }
 
-extension Document {
-    public var localFileUrl: URL {
-        let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        return directory.appendingPathComponent(id.uuidString).appendingPathExtension("pdf")
-    }
-}
-
 extension Document: CustomStringConvertible {
     public var description: String {
         "Document(id: \(id), name: \(name), ownerId: \(ownerId), " +


### PR DESCRIPTION
Cleanup from sprint 2
- Remove direct accesses on `LocalStorage` and `FirebaseStorage`